### PR TITLE
Enable publication at crates.io

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,19 +7,19 @@ license = "BSD"
 description = "EDHOC crypto library dispatch crate"
 
 [dependencies]
-edhoc-consts = { path = "../consts", default-features = false }
+edhoc-consts = { path = "../consts", version = "0.1.0", default-features = false }
 
 # hacspec
-edhoc-crypto-hacspec = { path = "./edhoc-crypto-hacspec", optional = true }
+edhoc-crypto-hacspec = { path = "./edhoc-crypto-hacspec", version = "0.1.0", optional = true }
 
 # cc2538 hardware accelerated
-edhoc-crypto-cc2538 = { path = "./edhoc-crypto-cc2538", optional = true }
+edhoc-crypto-cc2538 = { path = "./edhoc-crypto-cc2538", version = "0.1.0", optional = true }
 
 # psa
-edhoc-crypto-psa = { path = "./edhoc-crypto-psa", default-features = false, optional = true }
+edhoc-crypto-psa = { path = "./edhoc-crypto-psa", version = "0.1.0", default-features = false, optional = true }
 
 # cryptocell for nrf52840
-edhoc-crypto-cryptocell310 = { path = "./edhoc-crypto-cryptocell310-sys", optional = true }
+edhoc-crypto-cryptocell310 = { path = "./edhoc-crypto-cryptocell310-sys", version = "0.1.0", optional = true }
 
 [features]
 default = [  ]

--- a/crypto/edhoc-crypto-cc2538/Cargo.toml
+++ b/crypto/edhoc-crypto-cc2538/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD"
 description = "EDHOC crypto library cc2538 backend"
 
 [dependencies]
-edhoc-consts = { path = "../../consts" }
+edhoc-consts = { path = "../../consts", version = "0.1.0" }
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [ "alloc" ] }
 cortex-m = { version = "0.7.4" }
 cortex-m-rt = { version = "0.7.1" }

--- a/crypto/edhoc-crypto-hacspec/Cargo.toml
+++ b/crypto/edhoc-crypto-hacspec/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD"
 description = "EDHOC crypto library hacspec backend"
 
 [dependencies]
-edhoc-consts = { path = "../../consts", default-features = false, features = ["hacspec"] }
+edhoc-consts = { path = "../../consts", version = "0.1.0", default-features = false, features = ["hacspec"] }
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false }
 hacspec-p256 = { version = "0.1.0" }
 hacspec-hkdf = { version = "0.1.0" }

--- a/crypto/edhoc-crypto-psa/Cargo.toml
+++ b/crypto/edhoc-crypto-psa/Cargo.toml
@@ -7,7 +7,7 @@ license = "BSD"
 description = "EDHOC crypto library PSA backend"
 
 [dependencies]
-edhoc-consts = { path = "../../consts" }
+edhoc-consts = { path = "../../consts", version = "0.1.0" }
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [ "alloc" ], optional = true }
 psa-crypto = { version = "0.9.2" }
 

--- a/ead/Cargo.toml
+++ b/ead/Cargo.toml
@@ -7,10 +7,10 @@ license = "BSD"
 description = "EDHOC EAD library dispatch crate"
 
 [dependencies]
-edhoc-consts = { path = "../consts", default-features = false }
+edhoc-consts = { path = "../consts", version = "0.1.0", default-features = false }
 
-edhoc-ead-none = { path = "./edhoc-ead-none", optional = true }
-edhoc-ead-zeroconf = { path = "./edhoc-ead-zeroconf", optional = true }
+edhoc-ead-none = { path = "./edhoc-ead-none", version = "0.1.0", optional = true }
+edhoc-ead-zeroconf = { path = "./edhoc-ead-zeroconf", version = "0.1.0", optional = true }
 
 [features]
 default = [ "ead-none" ]

--- a/ead/edhoc-ead-none/Cargo.toml
+++ b/ead/edhoc-ead-none/Cargo.toml
@@ -7,4 +7,4 @@ license = "BSD"
 description = "EDHOC EAD none (just a placeholder)"
 
 [dependencies]
-edhoc-consts = { path = "../../consts" }
+edhoc-consts = { path = "../../consts", version = "0.1.0" }

--- a/ead/edhoc-ead-zeroconf/Cargo.toml
+++ b/ead/edhoc-ead-zeroconf/Cargo.toml
@@ -7,4 +7,4 @@ license = "BSD"
 description = "EDHOC EAD zeroconf (draf-lake-authz)"
 
 [dependencies]
-edhoc-consts = { path = "../../consts" }
+edhoc-consts = { path = "../../consts", version = "0.1.0" }

--- a/hacspec/Cargo.toml
+++ b/hacspec/Cargo.toml
@@ -8,9 +8,9 @@ description = "EDHOC implementation"
 
 [dependencies]
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, features = [ "alloc" ] }
-edhoc-crypto = { path = "../crypto", default-features = false }
-edhoc-ead = { path = "../ead", default-features = false }
-edhoc-consts = { path = "../consts" }
+edhoc-crypto = { path = "../crypto", version = "0.1.0", default-features = false }
+edhoc-ead = { path = "../ead", version = "0.1.0", default-features = false }
+edhoc-consts = { path = "../consts", version = "0.1.0" }
 
 [features]
 default = [ "edhoc-ead/edhoc-ead-none" ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,11 +10,11 @@ description = "EDHOC implementation in Rust"
 hexlit = "0.5.3"
 hex = { version = "0.4.3", default-features = false }
 
-edhoc-hacspec = { path = "../hacspec", optional = true }
+edhoc-hacspec = { path = "../hacspec", version = "0.1.0", optional = true }
 hacspec-lib = { version = "0.1.0-beta.1", default-features = false, optional = true }
-edhoc-crypto = { path = "../crypto", default-features = false }
-edhoc-consts = { path = "../consts", default-features = false }
-edhoc-ead = { path = "../ead", default-features = false }
+edhoc-crypto = { path = "../crypto", version = "^0.1.0", default-features = false }
+edhoc-consts = { path = "../consts", version = "0.1.0", default-features = false }
+edhoc-ead = { path = "../ead", version = "0.1.0", default-features = false }
 panic-semihosting = { version = "0.6.0", features = ["exit"], optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
For exploring this crate, it would be helpful if it were uploaded to crates.io.

I've started adding a few version numbers in dependencies to make that work, but there are some showstoppers along the way which I'd like to track here:

* [ ] https://github.com/thvdveld/cc2538-hal/pull/2
* [ ] The published version of psa-crypto has no baremetal feature:
    ```
    error: failed to verify package tarball

    Caused by:
      failed to select a version for `psa-crypto`.
          ... required by package `edhoc-crypto-psa v0.1.0 (/home/chrysn/.cache/cargo-target/package/edhoc-crypto-psa-0.1.0)`
      versions that meet the requirements `^0.9.2` are: 0.9.2

      the package `edhoc-crypto-psa` depends on `psa-crypto`, with features: `baremetal` but `psa-crypto` does not have these features.


      failed to select a version for `psa-crypto` which could resolve this conflict
    ```
    (My guess is that that is a check that only happens when the feature is selected, and it didn't get selected during builds?)

This PR should contain valid changes with our without fixes to the above; once all of those are in, I'd appreciate if the maintainers would consider publication, as it helps with visibility and makes the documentation accessible more easily. (It'd also help dependent projects in their own publication, but I'm not at the point yet where I have something there).