### PR TITLE
Privatize EADItem details, increase label range to i16

### DIFF
--- a/ead/edhoc-ead-zeroconf/src/lib.rs
+++ b/ead/edhoc-ead-zeroconf/src/lib.rs
@@ -39,7 +39,7 @@ pub fn ead_initiator_set_global_state(new_state: EADInitiatorState) {
 
 pub fn i_prepare_ead_1() -> Option<EADItem> {
     // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
-    let mut ead_1 = EADItem::new(EAD_ZEROCONF_LABEL.into(), true, None)
+    let mut ead_1 = EADItem::new(EAD_ZEROCONF_LABEL, true, None)
         // Const propagation will remove this.
         .unwrap();
 
@@ -114,7 +114,7 @@ pub fn r_process_ead_1(ead_1: EADItem) -> Result<(), ()> {
 
 pub fn r_prepare_ead_2() -> Option<EADItem> {
     // TODO: append Voucher (H(message_1), CRED_V) to the buffer
-    let ead_2 = EADItem::new(EAD_ZEROCONF_LABEL.into(), true, None).unwrap();
+    let ead_2 = EADItem::new(EAD_ZEROCONF_LABEL, true, None).unwrap();
 
     // NOTE: see the note in lib.rs::test_ead
     // state.protocol_state = EADResponderProtocolState::WaitMessage3;

--- a/ead/edhoc-ead-zeroconf/src/lib.rs
+++ b/ead/edhoc-ead-zeroconf/src/lib.rs
@@ -38,13 +38,10 @@ pub fn ead_initiator_set_global_state(new_state: EADInitiatorState) {
 }
 
 pub fn i_prepare_ead_1() -> Option<EADItem> {
-    let mut ead_1 = EADItem::new();
-
-    // this ead item is critical
-    ead_1.label = EAD_ZEROCONF_LABEL;
-    ead_1.is_critical = true;
-
     // TODO: build Voucher_Info (LOC_W, ENC_ID), and append it to the buffer
+    let mut ead_1 = EADItem::new(EAD_ZEROCONF_LABEL.into(), true, None)
+        // Const propagation will remove this.
+        .unwrap();
 
     ead_initiator_set_global_state(EADInitiatorState {
         protocol_state: EADInitiatorProtocolState::WaitEAD2,
@@ -65,7 +62,7 @@ pub fn i_process_ead_2(ead_2: EADItem) -> Result<(), ()> {
 }
 
 pub fn i_prepare_ead_3() -> Option<EADItem> {
-    Some(EADItem::new())
+    Some(EADItem::new(0, false, None).unwrap())
 }
 
 // responder side
@@ -116,13 +113,8 @@ pub fn r_process_ead_1(ead_1: EADItem) -> Result<(), ()> {
 }
 
 pub fn r_prepare_ead_2() -> Option<EADItem> {
-    let mut ead_2 = EADItem::new();
-
-    // add the label to the buffer (non-critical)
-    ead_2.label = EAD_ZEROCONF_LABEL;
-    ead_2.is_critical = true;
-
     // TODO: append Voucher (H(message_1), CRED_V) to the buffer
+    let ead_2 = EADItem::new(EAD_ZEROCONF_LABEL.into(), true, None).unwrap();
 
     // NOTE: see the note in lib.rs::test_ead
     // state.protocol_state = EADResponderProtocolState::WaitMessage3;

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1533,7 +1533,7 @@ mod tests {
     const MESSAGE_1_TV_SUITE_ONLY_C: &str = "0382021819";
     // message with an array having too many cipher suites (more than 9)
     const MESSAGE_1_TV_SUITE_ONLY_ERR: &str = "038A02020202020202020202";
-    const EAD_DUMMY_LABEL_TV: u8 = 0x01;
+    const EAD_DUMMY_LABEL_TV: u16 = 0x01;
     const EAD_DUMMY_VALUE_TV: &str = "cccccc";
     const EAD_DUMMY_CRITICAL_TV: &str = "20cccccc";
     const MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV: &str =


### PR DESCRIPTION
While it has practical uses (I'd like to utilize the library with https://datatracker.ietf.org/doc/draft-amsuess-core-edhoc-grease/, although that'll need the u16 or practically i32 points), its main purpose is to check whether my understanding of the code is good enough to pass CI.

I'd still ask for reviews towards merging because
* having fewer pub items makes for a better evolvable library, and
* I expect that EAD extensions that are somewhat larger will stay clear of the u8 range to leave it for every-byte-counts applications.