### PR TITLE
doc: Add README for shared, and link READMEs in the crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ resolver = "2"
 version = "0.4.1"
 repository = "https://github.com/openwsn-berkeley/edhoc-rs/"
 license = "BSD-3-Clause"
+readme = "shared/README.md"
 
 [workspace.dependencies]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library dispatch crate"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared = { package = "lakers-shared", path = "../shared", default-features = false }

--- a/crypto/lakers-crypto-cc2538/Cargo.toml
+++ b/crypto/lakers-crypto-cc2538/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library cc2538 backend"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-cryptocell310-sys/Cargo.toml
+++ b/crypto/lakers-crypto-cryptocell310-sys/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "ARM CryptoCell 310 sys crate"
 links = "nrf_cc310_0.9.13"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-hacspec/Cargo.toml
+++ b/crypto/lakers-crypto-hacspec/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library hacspec backend"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-psa/Cargo.toml
+++ b/crypto/lakers-crypto-psa/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 description = "EDHOC crypto library PSA backend"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-rustcrypto/Cargo.toml
+++ b/crypto/lakers-crypto-rustcrypto/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Christian Amsüss <chrysn@fsfe.org>" ]
 license.workspace = true
 description = "EDHOC crypto library backend based on the RustCrypto crates"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/ead/Cargo.toml
+++ b/ead/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
 license.workspace = true
 description = "EDHOC EAD library dispatch crate"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/ead/lakers-ead-none/Cargo.toml
+++ b/ead/lakers-ead-none/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
 license.workspace = true
 description = "EDHOC EAD none (just a placeholder)"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/ead/lakers-ead-zeroconf/Cargo.toml
+++ b/ead/lakers-ead-zeroconf/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
 license.workspace = true
 description = "EDHOC EAD zeroconf (draf-lake-authz)"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC implementation in Rust"
 repository.workspace = true
+readme = "../README.md"
 
 [dependencies]
 lakers-shared.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library constants crate"
 repository.workspace = true
+# It's implied, but still better for consistency to have it explicit.
+readme.workspace = true
 
 [dev-dependencies]
 hexlit = "0.5.3"

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,3 @@
+This crate is part of [lakers], a microcontroller-optimized implementation of EDHOC in Rust.
+
+[lakers]: https://crates.io/crates/lakers


### PR DESCRIPTION
This should fix the big looming "appears to have no README.md file" texts on crates.io. I don't think we can really test this other than wait what it looks like after the next release, but the absense of "unused manifest key" warnings in a cargo check is a good sign.

The main crate just uses the top-level README; all others use a shared one that points to the main crate.