### PR TITLE
doc: Add a few high-level introductory descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ resolver = "2"
 version = "0.4.1"
 repository = "https://github.com/openwsn-berkeley/edhoc-rs/"
 license = "BSD-3-Clause"
+readme = "shared/README.md"
 
 [workspace.dependencies]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library dispatch crate"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared = { package = "lakers-shared", path = "../shared", default-features = false }

--- a/crypto/lakers-crypto-cc2538/Cargo.toml
+++ b/crypto/lakers-crypto-cc2538/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library cc2538 backend"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-cryptocell310-sys/Cargo.toml
+++ b/crypto/lakers-crypto-cryptocell310-sys/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "ARM CryptoCell 310 sys crate"
 links = "nrf_cc310_0.9.13"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-hacspec/Cargo.toml
+++ b/crypto/lakers-crypto-hacspec/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library hacspec backend"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-psa/Cargo.toml
+++ b/crypto/lakers-crypto-psa/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 description = "EDHOC crypto library PSA backend"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/crypto/lakers-crypto-rustcrypto/Cargo.toml
+++ b/crypto/lakers-crypto-rustcrypto/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Christian Amsüss <chrysn@fsfe.org>" ]
 license.workspace = true
 description = "EDHOC crypto library backend based on the RustCrypto crates"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/ead/Cargo.toml
+++ b/ead/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
 license.workspace = true
 description = "EDHOC EAD library dispatch crate"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/ead/lakers-ead-none/Cargo.toml
+++ b/ead/lakers-ead-none/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
 license.workspace = true
 description = "EDHOC EAD none (just a placeholder)"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/ead/lakers-ead-zeroconf/Cargo.toml
+++ b/ead/lakers-ead-zeroconf/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Geovane Fedrecheski <geonnave@gmail.com>"]
 license.workspace = true
 description = "EDHOC EAD zeroconf (draf-lake-authz)"
 repository.workspace = true
+readme.workspace = true
 
 [dependencies]
 lakers-shared.workspace = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC implementation in Rust"
 repository.workspace = true
+readme = "../README.md"
 
 [dependencies]
 lakers-shared.workspace = true

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,18 @@
+//! Implementation of [EDHOC] (Ephemeral Diffie-Hellman Over COSE), a lightweight authenticated key
+//! exchange for the Internet of Things.
+//!
+//! The crate provides a high-level interface through the [EdhocInitiator] and the [EdhocResponder]
+//! structs. Both these wrap the lower level [State] struct that is mainly used through internal
+//! functions in the `edhoc` module. This separation is relevant because the lower level tools are
+//! subject of ongoing formal verification, whereas the high-level interfaces aim for good
+//! usability.
+//!
+//! Both [EdhocInitiator] and [EdhocResponder] are used in a type stated way. Following the EDHOC
+//! protocol, they generate (or process) messages, progressively provide more information about
+//! their peer, and on eventually devolve into an [EdhocInitiatorDone] and [EdhocResponderDone],
+//! respectively, through which the EDHOC key material can be obtained.
+//!
+//! [EDHOC]: https://datatracker.ietf.org/doc/draft-ietf-lake-edhoc/
 #![cfg_attr(not(test), no_std)]
 
 pub use {
@@ -10,6 +25,7 @@ pub use lakers_ead::*;
 mod edhoc;
 use edhoc::*;
 
+/// Starting point for performing EDHOC in the role of the Initiator.
 #[derive(Debug)]
 pub struct EdhocInitiator<'a, Crypto: CryptoTrait> {
     state: EdhocState<Start>, // opaque state
@@ -41,6 +57,7 @@ pub struct EdhocInitiatorDone<Crypto: CryptoTrait> {
     crypto: Crypto,
 }
 
+/// Starting point for performing EDHOC in the role of the Responder.
 #[derive(Debug)]
 pub struct EdhocResponder<'a, Crypto: CryptoTrait> {
     state: EdhocState<Start>, // opaque state

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
 description = "EDHOC crypto library constants crate"
 repository.workspace = true
+# It's implied, but still better for consistency to have it explicit.
+readme.workspace = true
 
 [dev-dependencies]
 hexlit = "0.5.3"

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,3 @@
+This crate is part of [lakers], a microcontroller-optimized implementation of EDHOC in Rust.
+
+[lakers]: https://crates.io/crates/lakers

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,12 @@
+//! Common data structures used by [lakers] and its dependent crates
+//!
+//! This crate is separate from lakers to avoid circular dependencies that would otherwise arise
+//! from the pattern in which [lakers-ead-dispatch] combined the main crate with variations of the
+//! protocol's EAD handling. As its types will then likely move over into the main lakers crate, it
+//! is recommended to use them through the public re-export there wherever possible.
+//!
+//! [lakers]: https://docs.rs/lakers/
+//! [lakers-ead-dispatch]: https://docs.rs/lakers-ead-dispatch/latest/lakers_ead_dispatch/
 #![no_std]
 
 use core::marker::PhantomData;
@@ -160,6 +169,10 @@ impl Default for State<Start> {
     }
 }
 
+/// An owned u8 vector of a limited length
+///
+/// It is used to represent the various messages in encrypted and in decrypted form, as well as
+/// other data items. Its maximum length is [MAX_MESSAGE_SIZE_LEN].
 #[repr(C)]
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct EdhocMessageBuffer {


### PR DESCRIPTION
Building on #175, this makes the docs.rs pages a bit prettier, mainly adding top-level docs and some text about the most frequently used structs.

If you agree with the text in there this one should be easy and self-contained. I'll eventually want to add more, but leading there will be a round of revisiting whether a great many things really need to be public. (No harm in documenting private items, but public items are priorized higher).