### PR TITLE
Do not pass the peer's credential to the library wrapper

### DIFF
--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -27,8 +27,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     let timeout = Duration::new(5, 0);
     println!("Client request: {}", url);
 
-    let initiator =
-        EdhocInitiator::new(lakers_crypto::default_crypto(), &I, &CRED_I, Some(&CRED_R));
+    let initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), &I, &CRED_I);
 
     // Send Message 1 over CoAP and convert the response to byte
     let mut msg_1_buf = Vec::from([0xf5u8]); // EDHOC message_1 when transported over CoAP is prepended with CBOR true

--- a/examples/coap/src/bin/coapserver-coaphandler.rs
+++ b/examples/coap/src/bin/coapserver-coaphandler.rs
@@ -15,11 +15,11 @@ const R: &[u8] = &hex!("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3
 
 #[derive(Default, Debug)]
 struct EdhocHandler {
-    connections: Vec<(u8, EdhocResponderWaitM3<'static, Crypto>)>,
+    connections: Vec<(u8, EdhocResponderWaitM3<Crypto>)>,
 }
 
 impl EdhocHandler {
-    fn take_connection_by_c_r(&mut self, c_r: u8) -> Option<EdhocResponderWaitM3<'static, Crypto>> {
+    fn take_connection_by_c_r(&mut self, c_r: u8) -> Option<EdhocResponderWaitM3<Crypto>> {
         let index = self
             .connections
             .iter()
@@ -60,8 +60,7 @@ impl coap_handler::Handler for EdhocHandler {
         let starts_with_true = request.payload().get(0) == Some(&0xf5);
 
         if starts_with_true {
-            let responder =
-                EdhocResponder::new(lakers_crypto::default_crypto(), &R, &CRED_R, Some(&CRED_I));
+            let responder = EdhocResponder::new(lakers_crypto::default_crypto(), &R, &CRED_R);
 
             let response = responder
                 .process_message_1(&request.payload()[1..].try_into().expect("wrong length"));

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -31,12 +31,7 @@ fn main() {
             println!("Received message from {}", src);
             // This is an EDHOC message
             if request.message.payload[0] == 0xf5 {
-                let responder = EdhocResponder::new(
-                    lakers_crypto::default_crypto(),
-                    &R,
-                    &CRED_R,
-                    Some(&CRED_I),
-                );
+                let responder = EdhocResponder::new(lakers_crypto::default_crypto(), &R, &CRED_R);
 
                 let result = responder.process_message_1(
                     &request.message.payload[1..]

--- a/examples/edhoc-rs-no_std/src/main.rs
+++ b/examples/edhoc-rs-no_std/src/main.rs
@@ -73,8 +73,7 @@ fn main() -> ! {
     const _C_R_TV: [u8; 1] = hex!("27");
 
     fn test_new_initiator() {
-        let _initiator =
-            EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I, Some(CRED_R));
+        let _initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I);
     }
 
     test_new_initiator();
@@ -93,8 +92,7 @@ fn main() -> ! {
     println!("Test test_p256_keys passed.");
 
     fn test_prepare_message_1() {
-        let mut initiator =
-            EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I, Some(CRED_R));
+        let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I);
 
         let c_i: u8 =
             generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).into();
@@ -106,10 +104,8 @@ fn main() -> ! {
     println!("Test test_prepare_message_1 passed.");
 
     fn test_handshake() {
-        let mut initiator =
-            EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I, Some(CRED_R));
-        let responder =
-            EdhocResponder::new(lakers_crypto::default_crypto(), R, CRED_R, Some(CRED_I));
+        let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I);
+        let responder = EdhocResponder::new(lakers_crypto::default_crypto(), R, CRED_R);
 
         let (initiator, message_1) = initiator.prepare_message_1(None, &None).unwrap();
 


### PR DESCRIPTION
Since now the peer's credential is validated at the application side, there is no need to pass it in the constructor.