### PR TITLE
Explicitly set credential transfer option

### DIFF
--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -50,7 +50,8 @@ fn client_handshake() -> Result<(), EDHOCError> {
     let initiator = initiator.verify_message_2(&I, &CRED_I, valid_cred_r.as_slice())?;
 
     let mut msg_3 = Vec::from([c_r]);
-    let (mut initiator, message_3, prk_out) = initiator.prepare_message_3(&None)?;
+    let (mut initiator, message_3, prk_out) =
+        initiator.prepare_message_3(CredentialTransfer::ByReference, &None)?;
     msg_3.extend_from_slice(message_3.as_slice());
     println!("message_3 len = {}", msg_3.len());
 

--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -27,7 +27,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     let timeout = Duration::new(5, 0);
     println!("Client request: {}", url);
 
-    let initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), &I, &CRED_I);
+    let initiator = EdhocInitiator::new(lakers_crypto::default_crypto());
 
     // Send Message 1 over CoAP and convert the response to byte
     let mut msg_1_buf = Vec::from([0xf5u8]); // EDHOC message_1 when transported over CoAP is prepended with CBOR true
@@ -47,7 +47,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     let (initiator, c_r, id_cred_r, _ead_2) = initiator.parse_message_2(&message_2)?;
     let (valid_cred_r, _g_r) =
         credential_check_or_fetch(Some(CRED_R.try_into().unwrap()), id_cred_r).unwrap();
-    let initiator = initiator.verify_message_2(valid_cred_r.as_slice())?;
+    let initiator = initiator.verify_message_2(&I, &CRED_I, valid_cred_r.as_slice())?;
 
     let mut msg_3 = Vec::from([c_r]);
     let (mut initiator, message_3, prk_out) = initiator.prepare_message_3(&None)?;

--- a/examples/coap/src/bin/coapserver-coaphandler.rs
+++ b/examples/coap/src/bin/coapserver-coaphandler.rs
@@ -130,9 +130,9 @@ impl coap_handler::Handler for EdhocHandler {
         response.set_code(coap_numbers::code::CHANGED.try_into().ok().unwrap());
         match req {
             EdhocResponse::OkSend2 { c_r, responder } => {
-                let kid = IdCred::CompactKid(ID_CRED_R[3]);
-                let (responder, message_2) =
-                    responder.prepare_message_2(&kid, Some(c_r), &None).unwrap();
+                let (responder, message_2) = responder
+                    .prepare_message_2(CredentialTransfer::ByReference, Some(c_r), &None)
+                    .unwrap();
                 self.connections.push((c_r, responder));
                 response.set_payload(message_2.as_slice());
             }

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -42,9 +42,9 @@ fn main() {
                 if let Ok((responder, _ead_1)) = result {
                     let c_r =
                         generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto());
-                    let kid = IdCred::CompactKid(ID_CRED_R[3]);
-                    let (responder, message_2) =
-                        responder.prepare_message_2(&kid, Some(c_r), &None).unwrap();
+                    let (responder, message_2) = responder
+                        .prepare_message_2(CredentialTransfer::ByReference, Some(c_r), &None)
+                        .unwrap();
                     response.message.payload = Vec::from(message_2.as_slice());
                     // save edhoc connection
                     edhoc_connections.push((c_r, responder));

--- a/examples/edhoc-rs-no_std/src/main.rs
+++ b/examples/edhoc-rs-no_std/src/main.rs
@@ -110,8 +110,9 @@ fn main() -> ! {
         let (initiator, message_1) = initiator.prepare_message_1(None, &None).unwrap();
 
         let (responder, _ead_1) = responder.process_message_1(&message_1).unwrap();
-        let kid = IdCred::CompactKid(ID_CRED_R[3]);
-        let (responder, message_2) = responder.prepare_message_2(&kid, None, &None).unwrap();
+        let (responder, message_2) = responder
+            .prepare_message_2(CredentialTransfer::ByReference, None, &None)
+            .unwrap();
 
         let (initiator, c_r, id_cred_r, ead_2) = initiator.parse_message_2(&message_2).unwrap();
         let (valid_cred_r, g_r) =
@@ -120,7 +121,9 @@ fn main() -> ! {
             .verify_message_2(I, CRED_I, valid_cred_r.as_slice())
             .unwrap();
 
-        let (mut initiator, message_3, i_prk_out) = initiator.prepare_message_3(&None).unwrap();
+        let (mut initiator, message_3, i_prk_out) = initiator
+            .prepare_message_3(CredentialTransfer::ByReference, &None)
+            .unwrap();
 
         let (responder, id_cred_i, _ead_3) = responder.parse_message_3(&message_3).unwrap();
         let (valid_cred_i, g_i) =

--- a/examples/edhoc-rs-no_std/src/main.rs
+++ b/examples/edhoc-rs-no_std/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> ! {
     const _C_R_TV: [u8; 1] = hex!("27");
 
     fn test_new_initiator() {
-        let _initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I);
+        let _initiator = EdhocInitiator::new(lakers_crypto::default_crypto());
     }
 
     test_new_initiator();
@@ -92,7 +92,7 @@ fn main() -> ! {
     println!("Test test_p256_keys passed.");
 
     fn test_prepare_message_1() {
-        let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I);
+        let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto());
 
         let c_i: u8 =
             generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).into();
@@ -104,7 +104,7 @@ fn main() -> ! {
     println!("Test test_prepare_message_1 passed.");
 
     fn test_handshake() {
-        let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto(), I, CRED_I);
+        let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto());
         let responder = EdhocResponder::new(lakers_crypto::default_crypto(), R, CRED_R);
 
         let (initiator, message_1) = initiator.prepare_message_1(None, &None).unwrap();
@@ -116,7 +116,9 @@ fn main() -> ! {
         let (initiator, c_r, id_cred_r, ead_2) = initiator.parse_message_2(&message_2).unwrap();
         let (valid_cred_r, g_r) =
             credential_check_or_fetch(Some(CRED_R.try_into().unwrap()), id_cred_r).unwrap();
-        let initiator = initiator.verify_message_2(valid_cred_r.as_slice()).unwrap();
+        let initiator = initiator
+            .verify_message_2(I, CRED_I, valid_cred_r.as_slice())
+            .unwrap();
 
         let (mut initiator, message_3, i_prk_out) = initiator.prepare_message_3(&None).unwrap();
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -185,6 +185,11 @@ pub struct Completed {
     pub prk_exporter: BytesHashLen,
 }
 
+pub enum CredentialTransfer {
+    ByReference,
+    ByValue,
+}
+
 /// An owned u8 vector of a limited length
 ///
 /// It is used to represent the various messages in encrypted and in decrypted form, as well as


### PR DESCRIPTION
Addressing #187. 

With this:
1. no more need to pass information (kid or full credential) already present in cred_x (which already is in the state)
2. the choice of how to transfer the credential becomes more clear