### PR TITLE
Implement C_R included in MAC_2 computation

### DIFF
--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -155,6 +155,7 @@ pub struct ProcessingM2 {
     pub x: BytesP256ElemLen,
     pub g_y: BytesP256ElemLen,
     pub plaintext_2: EdhocMessageBuffer,
+    pub c_r: u8,
     pub ead_2: Option<EADItem>,
 }
 


### PR DESCRIPTION
Implementation of `C_R` included in the computation of `MAC_2`, as per https://github.com/lake-wg/edhoc/pull/455.

Test vectors are taken from https://github.com/lake-wg/edhoc/pull/456/commits/1b0927a312e980156d1f3703899014abd94efc2c

Fixes #190 