### PR TITLE
Add authz server with no acl (left for user app)

### DIFF
--- a/ead/lakers-ead-authz/src/lib.rs
+++ b/ead/lakers-ead-authz/src/lib.rs
@@ -9,7 +9,7 @@ mod test_vectors;
 
 pub use authenticator::{ZeroTouchAuthenticator, ZeroTouchAuthenticatorWaitVoucherResp};
 pub use device::{ZeroTouchDevice, ZeroTouchDeviceDone, ZeroTouchDeviceWaitEAD2};
-pub use server::ZeroTouchServer;
+pub use server::{ZeroTouchServer, ZeroTouchServerUserAcl};
 
 #[derive(PartialEq, Debug)]
 #[repr(C)]

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -319,7 +319,7 @@ mod test_server_stateless_operation {
     use lakers_crypto::default_crypto;
 
     #[test]
-    fn test_sloparse_voucher_request() {
+    fn test_slo_parse_voucher_request() {
         let voucher_request_tv: EdhocMessageBuffer = SLO_VOUCHER_REQUEST_TV.try_into().unwrap();
         let message_1_tv: EdhocMessageBuffer = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
         let opaque_state_tv: EdhocMessageBuffer = SLO_OPAQUE_STATE_TV.try_into().unwrap();

--- a/lakers-python/src/ead_authz/server.rs
+++ b/lakers-python/src/ead_authz/server.rs
@@ -35,3 +35,40 @@ impl PyAuthzEnrollmentServer {
         }
     }
 }
+
+#[pyclass(name = "AuthzServerUserAcl")]
+pub struct PyAuthzServerUserAcl {
+    server: ZeroTouchServerUserAcl,
+}
+
+#[pymethods]
+impl PyAuthzServerUserAcl {
+    #[new]
+    pub fn new(w: Vec<u8>, cred_v: Vec<u8>) -> Self {
+        let mut w_arr = BytesP256ElemLen::default();
+        w_arr.copy_from_slice(&w.as_slice());
+
+        Self {
+            server: ZeroTouchServerUserAcl::new(w_arr, cred_v.as_slice()),
+        }
+    }
+
+    fn decode_voucher_request<'a>(&self, py: Python<'a>, vreq: Vec<u8>) -> PyResult<&'a PyBytes> {
+        let vreq = EdhocMessageBuffer::new_from_slice(vreq.as_slice()).unwrap();
+        match self
+            .server
+            .decode_voucher_request(&mut default_crypto(), &vreq)
+        {
+            Ok(id_u) => Ok(PyBytes::new(py, id_u.as_slice())),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn prepare_voucher<'a>(&self, py: Python<'a>, vreq: Vec<u8>) -> PyResult<&'a PyBytes> {
+        let vreq = EdhocMessageBuffer::new_from_slice(vreq.as_slice()).unwrap();
+        match self.server.prepare_voucher(&mut default_crypto(), &vreq) {
+            Ok(voucher_response) => Ok(PyBytes::new(py, voucher_response.as_slice())),
+            Err(error) => Err(error.into()),
+        }
+    }
+}

--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -66,5 +66,6 @@ fn lakers_python(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ead_authz::PyAuthzDevice>()?;
     m.add_class::<ead_authz::PyAuthzAutenticator>()?;
     m.add_class::<ead_authz::PyAuthzEnrollmentServer>()?;
+    m.add_class::<ead_authz::PyAuthzServerUserAcl>()?;
     Ok(())
 }

--- a/lakers-python/test/test_ead_authz.py
+++ b/lakers-python/test/test_ead_authz.py
@@ -35,6 +35,15 @@ def test_authenticator_and_server():
     assert ead_2.is_critical() == True
     assert ead_2.value() == EAD_2_VALUE
 
+def test_authenticator_and_server():
+    VOUCHER_REQUEST_TV = bytes.fromhex("8158520382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370158287818636f61703a2f2f656e726f6c6c6d656e742e7365727665724dda9784962883c96ed01ff122c3")
+    enrollment_server = lakers.AuthzServerUserAcl(W, CRED_V)
+
+    id_u = enrollment_server.decode_voucher_request(VOUCHER_REQUEST_TV)
+    assert id_u == ID_U
+    voucher_response = enrollment_server.prepare_voucher(VOUCHER_REQUEST_TV)
+    assert type(voucher_response) == bytes
+
 def test_handshake_with_authz():
     initiator = lakers.EdhocInitiator()
     responder = lakers.EdhocResponder(V, CRED_V)


### PR DESCRIPTION
This adds a new Authz server that has no ACL -- it instead leaves the decision of allowing or not access to the application.