### PR TITLE
Add cpp_compat for C headers

### DIFF
--- a/lakers-c/cbindgen.toml
+++ b/lakers-c/cbindgen.toml
@@ -10,6 +10,7 @@ header = """
  */"""
 include_guard = "LAKERS_C_H"
 includes = ["lakers_shared.h", "lakers_ead_authz.h"]
+cpp_compat = true
 
 [parse.expand]
 all_features = true

--- a/shared/cbindgen.toml
+++ b/shared/cbindgen.toml
@@ -9,6 +9,7 @@ header = """
  * ================================================================================================
  */"""
 include_guard = "LAKERS_SHARED_H"
+cpp_compat = true
 
 [export]
 include = [


### PR DESCRIPTION
This affects the headers for the lakers_shared and lakers_c libraries.

Closes #230 