### PR TITLE
examples/coap: Update to new traits

### DIFF
--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -12,9 +12,10 @@ coap = { version = "0.13" }
 coap-lite = { version = "0.11.3" }
 
 std-embedded-nal = "^0.1.2"
-embedded-nal-minimal-coapserver = "0.3.1"
+embedded-nal-minimal-coapserver = "0.4"
 embedded-nal = "0.6"
-coap-message = "0.2.3"
-coap-handler = "0.1.5"
-coap-handler-implementations = "0.4.2"
+coap-message = "0.3"
+coap-handler = "0.2"
+coap-handler-implementations = "0.5"
 coap-numbers = "0.2.3"
+coap-message-utils = "0.3.1"

--- a/examples/coap/src/bin/coapserver-coaphandler.rs
+++ b/examples/coap/src/bin/coapserver-coaphandler.rs
@@ -67,6 +67,8 @@ impl coap_handler::Handler for EdhocHandler {
             return Err(Error::method_not_allowed());
         }
 
+        println!("{:?}", self);
+
         request.options().ignore_elective_others()?;
 
         let first_byte = request.payload().get(0).ok_or_else(Error::bad_request)?;
@@ -113,7 +115,6 @@ impl coap_handler::Handler for EdhocHandler {
             let result = responder.parse_message_3(&message_3);
             let (responder, id_cred_i, _ead_3) = result.map_err(|e| {
                 println!("EDHOC processing error: {:?}", e);
-                // FIXME remove state from edhoc_connections
                 // FIXME: Produce proper error
                 Error::bad_request()
             })?;
@@ -126,7 +127,6 @@ impl coap_handler::Handler for EdhocHandler {
             let (mut responder, prk_out) =
                 responder.verify_message_3(valid_cred_i).map_err(|e| {
                     println!("EDHOC processing error: {:?}", e);
-                    // FIXME remove state from edhoc_connections
                     // FIXME: Produce proper error
                     Error::bad_request()
                 })?;


### PR DESCRIPTION
This vastly enhances error handling.

This is still a PR because I think that EDHOCError should become renderable, so that EDHOC errors can fly out through `?`.