### PR TITLE
shared: Remove numeric value, repr(C) and UnknownError from EDHOCError

### DIFF
--- a/ead/lakers-ead-authz/src/authenticator.rs
+++ b/ead/lakers-ead-authz/src/authenticator.rs
@@ -22,7 +22,7 @@ impl ZeroTouchAuthenticator {
         let opaque_state: Option<EdhocMessageBuffer> = None; // TODO: receive as parameter
 
         if ead_1.label != EAD_ZEROCONF_LABEL || ead_1.value.is_none() {
-            return Err(EDHOCError::EADError);
+            return Err(EDHOCError::EADUnprocessable);
         }
 
         let (loc_w, _enc_id) = parse_ead_1_value(&ead_1.value.unwrap())?;
@@ -92,7 +92,7 @@ fn parse_voucher_response(
 
     let array_size = decoder.array()?;
     if !(2..=3).contains(&array_size) {
-        return Err(EDHOCError::EADError);
+        return Err(EDHOCError::EADUnprocessable);
     }
 
     let message_1: EdhocMessageBuffer = decoder.bytes()?.try_into().unwrap();

--- a/ead/lakers-ead-authz/src/lib.rs
+++ b/ead/lakers-ead-authz/src/lib.rs
@@ -92,6 +92,6 @@ mod test_authz {
 
         let voucher_response =
             server.handle_voucher_request(&mut default_crypto(), &voucher_request);
-        assert_eq!(voucher_response.unwrap_err(), EDHOCError::EADError);
+        assert_eq!(voucher_response.unwrap_err(), EDHOCError::AccessDenied);
     }
 }

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -48,7 +48,7 @@ impl ZeroTouchServer {
             let voucher_response = encode_voucher_response(&message_1, &voucher, &opaque_state);
             Ok(voucher_response)
         } else {
-            Err(EDHOCError::EADError)
+            Err(EDHOCError::AccessDenied)
         }
     }
 }
@@ -107,7 +107,7 @@ fn parse_voucher_request(
     let mut decoder = CBORDecoder::new(vreq.as_slice());
     let array_size = decoder.array()?;
     if array_size != 1 && array_size != 2 {
-        return Err(EDHOCError::EADError);
+        return Err(EDHOCError::EADUnprocessable);
     }
 
     let message_1: EdhocMessageBuffer = decoder.bytes()?.try_into().unwrap();
@@ -277,7 +277,7 @@ mod test_enrollment_server {
             &mut default_crypto(),
             &VOUCHER_REQUEST_TV.try_into().unwrap(),
         );
-        assert_eq!(res.unwrap_err(), EDHOCError::EADError);
+        assert_eq!(res.unwrap_err(), EDHOCError::AccessDenied);
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -446,7 +446,7 @@ pub fn credential_check_or_fetch<'a>(
         if credentials_match {
             Ok(cred_expected)
         } else {
-            Err(EDHOCError::UnknownPeer)
+            Err(EDHOCError::UnexpectedCredential)
         }
     } else {
         // 1. Does ID_CRED_X point to a stored authentication credential? NO

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -107,15 +107,15 @@ pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD
 #[repr(C)]
 #[derive(PartialEq, Debug)]
 pub enum EDHOCError {
-    UnknownPeer = 1,
-    MacVerificationFailed = 2,
-    UnsupportedMethod = 3,
-    UnsupportedCipherSuite = 4,
-    ParsingError = 5,
-    EadLabelTooLongError = 6,
-    EadTooLongError = 7,
-    EADError = 8,
-    UnknownError = 9,
+    UnknownPeer,
+    MacVerificationFailed,
+    UnsupportedMethod,
+    UnsupportedCipherSuite,
+    ParsingError,
+    EadLabelTooLongError,
+    EadTooLongError,
+    EADError,
+    UnknownError,
 }
 
 #[derive(Debug)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -120,7 +120,15 @@ pub enum EDHOCError {
     ParsingError,
     EadLabelTooLongError,
     EadTooLongError,
-    EADError,
+    /// An EAD was received that was either not known (and critical), or not understood, or
+    /// otherwise erroneous.
+    EADUnprocessable,
+    /// The credential or EADs could be processed (possibly by a third party), but the decision
+    /// based on that was to not to continue the EDHOC session.
+    ///
+    /// See also
+    /// <https://datatracker.ietf.org/doc/html/draft-ietf-lake-authz#name-edhoc-error-access-denied>
+    AccessDenied,
 }
 
 impl EDHOCError {
@@ -147,7 +155,8 @@ impl EDHOCError {
             ParsingError => ErrCode::UNSPECIFIED,
             EadLabelTooLongError => ErrCode::UNSPECIFIED,
             EadTooLongError => ErrCode::UNSPECIFIED,
-            EADError => ErrCode::ACCESS_DENIED,
+            EADUnprocessable => ErrCode::UNSPECIFIED,
+            AccessDenied => ErrCode::ACCESS_DENIED,
         }
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -109,7 +109,11 @@ pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD
 #[derive(PartialEq, Debug)]
 #[non_exhaustive]
 pub enum EDHOCError {
-    UnknownPeer,
+    /// In an exchange, a credential was set as "expected", but the credential configured by the
+    /// peer did not match what was presented. This is more an application internal than an EDHOC
+    /// error: When the application sets the expected credential, that process should be informed
+    /// by the known details.
+    UnexpectedCredential,
     MacVerificationFailed,
     UnsupportedMethod,
     UnsupportedCipherSuite,
@@ -136,7 +140,7 @@ impl EDHOCError {
     pub fn err_code(&self) -> ErrCode {
         use EDHOCError::*;
         match self {
-            UnknownPeer => ErrCode::UNKNOWN_CREDENTIAL,
+            UnexpectedCredential => ErrCode::UNSPECIFIED,
             MacVerificationFailed => ErrCode::UNSPECIFIED,
             UnsupportedMethod => ErrCode::UNSPECIFIED,
             UnsupportedCipherSuite => ErrCode::WRONG_SELECTED_CIPHER_SUITE,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -106,6 +106,7 @@ pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD
 
 #[repr(C)]
 #[derive(PartialEq, Debug)]
+#[non_exhaustive]
 pub enum EDHOCError {
     UnknownPeer,
     MacVerificationFailed,
@@ -115,7 +116,6 @@ pub enum EDHOCError {
     EadLabelTooLongError,
     EadTooLongError,
     EADError,
-    UnknownError,
 }
 
 #[derive(Debug)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -104,7 +104,6 @@ pub type BytesMac = [u8; MAC_LENGTH];
 pub type BytesEncodedVoucher = [u8; ENCODED_VOUCHER_LEN];
 pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD_SIZE_LEN
 
-#[repr(C)]
 #[derive(PartialEq, Debug)]
 #[non_exhaustive]
 pub enum EDHOCError {


### PR DESCRIPTION
The numbers associated to EDHOCError are confusing because they do not match the EDHOC ERR_INFO numeric values. Let's try whether we really need them.

(Frankly, at this stage this is looking for whether CI takes it).