### PR TITLE
examples/c: Fix use of CoAP

### DIFF
--- a/examples/lakers-c-native/main.c
+++ b/examples/lakers-c-native/main.c
@@ -57,7 +57,8 @@ int coap_send_edhoc_message(uint8_t *edhoc_msg, size_t edhoc_msg_len, uint8_t va
                                     COAP_REQUEST_CODE_GET,
                                     coap_new_message_id(session),
                                     coap_session_max_pdu_size(session));
-    coap_add_option(pdu, COAP_OPTION_URI_PATH, 17, (const uint8_t *)".well-known/edhoc");
+    coap_add_option(pdu, COAP_OPTION_URI_PATH, 11, (const uint8_t *)".well-known");
+    coap_add_option(pdu, COAP_OPTION_URI_PATH, 5, (const uint8_t *)"edhoc");
     uint8_t payload[MAX_MESSAGE_SIZE_LEN];
     payload[0] = value_to_prepend;
     memcpy(payload + 1, edhoc_msg, edhoc_msg_len);

--- a/examples/lakers-c-native/main.c
+++ b/examples/lakers-c-native/main.c
@@ -54,7 +54,7 @@ int coap_send_edhoc_message(uint8_t *edhoc_msg, size_t edhoc_msg_len, uint8_t va
 {
     printf("sending coap message of size %zu+1\n", edhoc_msg_len);
     coap_pdu_t *pdu = coap_pdu_init(COAP_MESSAGE_CON,
-                                    COAP_REQUEST_CODE_GET,
+                                    COAP_REQUEST_CODE_POST,
                                     coap_new_message_id(session),
                                     coap_session_max_pdu_size(session));
     coap_add_option(pdu, COAP_OPTION_URI_PATH, 11, (const uint8_t *)".well-known");


### PR DESCRIPTION
These changes enable the lakers-c-native client application to run against the stricter coapserver-coaphandler implementation.