### PR TITLE
coapserver-coaphandler: Restore feature parity with coapserver

### DIFF
--- a/examples/lakers-c-native/main.c
+++ b/examples/lakers-c-native/main.c
@@ -57,7 +57,8 @@ int coap_send_edhoc_message(uint8_t *edhoc_msg, size_t edhoc_msg_len, uint8_t va
                                     COAP_REQUEST_CODE_GET,
                                     coap_new_message_id(session),
                                     coap_session_max_pdu_size(session));
-    coap_add_option(pdu, COAP_OPTION_URI_PATH, 17, (const uint8_t *)".well-known/edhoc");
+    coap_add_option(pdu, COAP_OPTION_URI_PATH, 11, (const uint8_t *)".well-known");
+    coap_add_option(pdu, COAP_OPTION_URI_PATH, 5, (const uint8_t *)"edhoc");
     uint8_t payload[MAX_MESSAGE_SIZE_LEN];
     payload[0] = value_to_prepend;
     memcpy(payload + 1, edhoc_msg, edhoc_msg_len);

--- a/examples/lakers-c-native/main.c
+++ b/examples/lakers-c-native/main.c
@@ -54,7 +54,7 @@ int coap_send_edhoc_message(uint8_t *edhoc_msg, size_t edhoc_msg_len, uint8_t va
 {
     printf("sending coap message of size %zu+1\n", edhoc_msg_len);
     coap_pdu_t *pdu = coap_pdu_init(COAP_MESSAGE_CON,
-                                    COAP_REQUEST_CODE_GET,
+                                    COAP_REQUEST_CODE_POST,
                                     coap_new_message_id(session),
                                     coap_session_max_pdu_size(session));
     coap_add_option(pdu, COAP_OPTION_URI_PATH, 11, (const uint8_t *)".well-known");


### PR DESCRIPTION
authz support was added to the coapserver but not to coapserver-coaphandler; this fixes the regression.

This is based on #238 because the C client's bugs were hidden by coapserver's lax handling (see https://github.com/martindisch/coap-lite/issues/36), and would otherwise make it unusable for even basic testing.