### PR TITLE
testing: re-enable hacspec backend

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crypto_backend: [lakers-crypto/psa, lakers-crypto/rustcrypto]
+        crypto_backend: [lakers-crypto/psa, lakers-crypto/rustcrypto, lakers-crypto/hacspec]
         ead: [ead-none, ead-authz]
 
     steps:
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crypto_backend: [lakers-crypto/psa, lakers-crypto/psa-baremetal, lakers-crypto/cryptocell310, lakers-crypto/rustcrypto]
+        crypto_backend: [lakers-crypto/psa, lakers-crypto/psa-baremetal, lakers-crypto/cryptocell310, lakers-crypto/rustcrypto, lakers-crypto/hacspec]
         ead: [lakers-ead/ead-none, lakers-ead/ead-authz]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
   "ead/lakers-ead-authz",
   "crypto",
   "crypto/lakers-crypto-cc2538",
-  # "crypto/lakers-crypto-hacspec",
+  "crypto/lakers-crypto-hacspec",
   "crypto/lakers-crypto-psa",
   "crypto/lakers-crypto-rustcrypto",
   "crypto/lakers-crypto-cryptocell310-sys",
@@ -50,17 +50,17 @@ lakers-ead-authz = { package = "lakers-ead-authz", path = "ead/lakers-ead-authz/
 lakers-crypto = { path = "crypto/" }
 lakers-crypto-cc2538 = { path = "crypto/lakers-crypto-cc2538/" }
 lakers-crypto-cryptocell310 = { path = "crypto/lakers-crypto-cryptocell310-sys/" }
-# lakers-crypto-hacspec = { path = "crypto/lakers-crypto-hacspec/" }
+lakers-crypto-hacspec = { path = "crypto/lakers-crypto-hacspec/" }
 lakers-crypto-psa = { path = "crypto/lakers-crypto-psa/" }
 lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.5.1" }
 
 lakers = { package = "lakers", path = "lib/", version = "^0.5.1", default-features = false }
 
 [patch.crates-io]
-# hacspec-lib = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
-# hacspec-p256 = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
-# hacspec-hkdf = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
-# hacspec-sha256 = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
-# hacspec-aes = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
-# hacspec-aes-ccm = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
+hacspec-lib = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
+hacspec-p256 = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
+hacspec-hkdf = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
+hacspec-sha256 = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
+hacspec-aes = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
+hacspec-aes-ccm = { git = "https://github.com/malishav/hacspec", branch = "aesccm" }
 psa-crypto = { git = "https://github.com/malishav/rust-psa-crypto", branch = "baremetal" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true
 lakers-shared = { package = "lakers-shared", path = "../shared", default-features = false }
 
 # hacspec
-# lakers-crypto-hacspec = { workspace = true, optional = true }
+lakers-crypto-hacspec = { workspace = true, optional = true }
 
 # cc2538 hardware accelerated
 lakers-crypto-cc2538 = { workspace = true, optional = true }
@@ -33,7 +33,7 @@ rstest = "0.11.0"
 
 [features]
 default = [  ]
-# hacspec = [ "lakers-crypto-hacspec" ]
+hacspec = [ "lakers-crypto-hacspec" ]
 cc2538 = [ "lakers-crypto-cc2538" ]
 psa = [ "lakers-crypto-psa" ]
 psa-baremetal = [ "psa", "lakers-crypto-psa/baremetal" ]


### PR DESCRIPTION
It was previously disabled since it was failing to build on CI (external reason).

This is a test to see if that still happens.

If CI no longer fails, the backend can be re-enabled.