### PR TITLE
Loss of feature: "up to date with latest draft"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build and test](https://github.com/openwsn-berkeley/lakers/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/openwsn-berkeley/lakers/actions/workflows/build-and-test.yml)
 
-An implementation of [EDHOC](https://datatracker.ietf.org/doc/draft-ietf-lake-edhoc/) in Rust:
-- up-to-date with the [latest draft version (23)](https://datatracker.ietf.org/doc/draft-ietf-lake-edhoc/23/)
+An implementation of [EDHOC (RFC9528)](https://datatracker.ietf.org/doc/html/rfc9528) in Rust:
 - microcontroller-optimized: `no_std`, no heap allocations, zero-dependencies (other than crypto backends)
 - configurable crypto backends
 - bindings for [C](https://github.com/openwsn-berkeley/lakers/releases/) and [Python](https://pypi.org/project/lakers-python/)

--- a/lakers-python/test/test_lakers.py
+++ b/lakers-python/test/test_lakers.py
@@ -1,7 +1,7 @@
 import lakers
 import pytest
 
-# values from draft-ietf-lake-traces
+# values from RFC9529
 CRED_I = bytes.fromhex("A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8")
 I = bytes.fromhex("fb13adeb6518cee5f88417660841142e830a81fe334380a953406a1305e8706b")
 R = bytes.fromhex("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac")
@@ -57,7 +57,7 @@ def test_handshake():
     assert i_oscore_secret == r_oscore_secret
     assert i_oscore_salt == r_oscore_salt
 
-    # test key update with context from draft-ietf-lake-traces
+    # test key update with context from RFC9529
     i_prk_out_new = initiator.edhoc_key_update(CONTEXT)
     r_prk_out_new = responder.edhoc_key_update(CONTEXT)
     assert i_prk_out_new == r_prk_out_new

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -606,7 +606,7 @@ mod test {
         assert_eq!(i_oscore_secret, r_oscore_secret);
         assert_eq!(i_oscore_salt, r_oscore_salt);
 
-        // test key update with context from draft-ietf-lake-traces
+        // test key update with context from RFC9529
         let i_prk_out_new = initiator.edhoc_key_update(&[
             0xa0, 0x11, 0x58, 0xfd, 0xb8, 0x20, 0x89, 0x0c, 0xd6, 0xbe, 0x16, 0x96, 0x02, 0xb8,
             0xbc, 0xea,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,4 @@
-//! Implementation of [EDHOC] (Ephemeral Diffie-Hellman Over COSE), a lightweight authenticated key
+//! Implementation of [EDHOC] (Ephemeral Diffie-Hellman Over COSE, RFC9528), a lightweight authenticated key
 //! exchange for the Internet of Things.
 //!
 //! The crate provides a high-level interface through the [EdhocInitiator] and the [EdhocResponder]
@@ -12,7 +12,7 @@
 //! their peer, and on eventually devolve into an [EdhocInitiatorDone] and [EdhocResponderDone],
 //! respectively, through which the EDHOC key material can be obtained.
 //!
-//! [EDHOC]: https://datatracker.ietf.org/doc/draft-ietf-lake-edhoc/
+//! [EDHOC]: https://datatracker.ietf.org/doc/html/rfc9528
 #![cfg_attr(not(test), no_std)]
 
 pub use {lakers_shared::Crypto as CryptoTrait, lakers_shared::*};

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -27,7 +27,7 @@ impl CredentialRPK {
     }
 
     fn parse(cred: &[u8]) -> Result<(BytesP256ElemLen, u8), EDHOCError> {
-        // NOTE: this routine is only guaranteed to work with credentials from lake-traces
+        // NOTE: this routine is only guaranteed to work with credentials from RFC9529
         const CCS_PREFIX_LEN: usize = 3;
         const CNF_AND_COSE_KEY_PREFIX_LEN: usize = 8;
         const COSE_KEY_FIRST_ITEMS_LEN: usize = 6;


### PR DESCRIPTION
I'm sad to report that LAKERS can't claim to be up to date with the latest draft any more … because the latest thing isn't a draft!

This PR replaces references to the draft with RFC9528, references to the traces with RFC9529 (except in the ipynb which references the -07 traces), and removes the note on being up to date with the latest draft version.