### PR TITLE
python: Don't return Vec<u8>

### DIFF
--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -57,19 +57,20 @@ impl PyEdhocInitiator {
         }
     }
 
-    pub fn parse_message_2(
+    pub fn parse_message_2<'a>(
         &mut self,
+        py: Python<'a>,
         message_2: Vec<u8>,
-    ) -> PyResult<(u8, Vec<u8>, Option<EADItem>)> {
+    ) -> PyResult<(u8, &'a PyBytes, Option<EADItem>)> {
         let message_2 = EdhocMessageBuffer::new_from_slice(message_2.as_slice())?;
 
         match i_parse_message_2(&self.wait_m2, &mut default_crypto(), &message_2) {
             Ok((state, c_r, id_cred_r, ead_2)) => {
                 self.processing_m2 = state;
                 let id_cred_r = if id_cred_r.reference_only() {
-                    Vec::from([id_cred_r.kid])
+                    PyBytes::new(py, &[id_cred_r.kid])
                 } else {
-                    Vec::from(id_cred_r.value.as_slice())
+                    PyBytes::new(py, id_cred_r.value.as_slice())
                 };
                 Ok((c_r, id_cred_r, ead_2))
             }

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -72,15 +72,19 @@ impl PyEdhocResponder {
         }
     }
 
-    pub fn parse_message_3(&mut self, message_3: Vec<u8>) -> PyResult<(Vec<u8>, Option<EADItem>)> {
+    pub fn parse_message_3<'a>(
+        &mut self,
+        py: Python<'a>,
+        message_3: Vec<u8>,
+    ) -> PyResult<(&'a PyBytes, Option<EADItem>)> {
         let message_3 = EdhocMessageBuffer::new_from_slice(message_3.as_slice())?;
         match r_parse_message_3(&mut self.wait_m3, &mut default_crypto(), &message_3) {
             Ok((state, id_cred_i, ead_3)) => {
                 self.processing_m3 = state;
                 let id_cred_i = if id_cred_i.reference_only() {
-                    Vec::from([id_cred_i.kid])
+                    PyBytes::new(py, &[id_cred_i.kid])
                 } else {
-                    Vec::from(id_cred_i.value.as_slice())
+                    PyBytes::new(py, id_cred_i.value.as_slice())
                 };
                 Ok((id_cred_i, ead_3))
             }


### PR DESCRIPTION
The ID_CRED_x returned in the initiator and responder APIs are unintuitive for Python users when arrays (esp. if they see examples where it's a `[10]` style single value -- to a Python user that looks more like a parsed CBOR, more so if that is actually what parsing a CBOR sequence would give). Returning it as Python bytes makes it easier to understand that this is the opaque data indicating either an identifier or a credential by value.

Closes: https://github.com/openwsn-berkeley/lakers/issues/256