### PR TITLE
C_x: Represent using own ConnectionIdentifier newtype

### DIFF
--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -51,7 +51,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     let valid_cred_r = credential_check_or_fetch(Some(cred_r), id_cred_r).unwrap();
     let initiator = initiator.verify_message_2(&I, cred_i, valid_cred_r)?;
 
-    let mut msg_3 = Vec::from([c_r]);
+    let mut msg_3 = Vec::from(c_r.as_cbor());
     let (mut initiator, message_3, prk_out) =
         initiator.prepare_message_3(CredentialTransfer::ByReference, &None)?;
     msg_3.extend_from_slice(message_3.as_slice());

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -83,7 +83,7 @@ fn main() {
             } else {
                 // potentially message 3
                 println!("Received message 3");
-                let c_r_rcvd = request.message.payload[0];
+                let c_r_rcvd = ConnId::from_int_raw(request.message.payload[0]);
                 // FIXME let's better not *panic here
                 let responder = take_state(c_r_rcvd, &mut edhoc_connections).unwrap();
 
@@ -141,8 +141,8 @@ fn main() {
 }
 
 fn take_state<R>(
-    c_r_rcvd: u8,
-    edhoc_protocol_states: &mut Vec<(u8, R)>,
+    c_r_rcvd: ConnId,
+    edhoc_protocol_states: &mut Vec<(ConnId, R)>,
 ) -> Result<R, &'static str> {
     for (i, element) in edhoc_protocol_states.iter().enumerate() {
         let (c_r, _responder) = element;

--- a/examples/lakers-no_std/src/main.rs
+++ b/examples/lakers-no_std/src/main.rs
@@ -83,8 +83,8 @@ fn main() -> ! {
     fn test_prepare_message_1() {
         let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto());
 
-        let c_i: u8 =
-            generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).into();
+        let c_i =
+            generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).as_slice();
         let message_1 = initiator.prepare_message_1(None, &None);
         assert!(message_1.is_ok());
     }

--- a/lakers-c/src/initiator.rs
+++ b/lakers-c/src/initiator.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn initiator_prepare_message_1(
     let c_i = if c_i.is_null() {
         generate_connection_identifier_cbor(crypto)
     } else {
-        *c_i
+        ConnId::from_int_raw(*c_i)
     };
 
     let ead_1 = if ead_1_c.is_null() {
@@ -108,7 +108,9 @@ pub unsafe extern "C" fn initiator_parse_message_2(
     let result = match i_parse_message_2(&state, crypto, &(*message_2)) {
         Ok((state, c_r, id_cred_r, ead_2)) => {
             ProcessingM2C::copy_into_c(state, &mut (*initiator_c).processing_m2);
-            *c_r_out = c_r;
+            let c_r = c_r.as_slice();
+            assert_eq!(c_r.len(), 1, "C API only supports short C_R");
+            *c_r_out = c_r[0];
             *id_cred_r_out = id_cred_r;
             if let Some(ead_2) = ead_2 {
                 EADItemC::copy_into_c(ead_2, ead_2_c_out);

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -86,7 +86,7 @@ impl ProcessingM2C {
             x: self.x,
             g_y: self.g_y,
             plaintext_2: self.plaintext_2,
-            c_r: self.c_r,
+            c_r: ConnId::from_int_raw(self.c_r),
             ead_2: if self.ead_2.is_null() {
                 None
             } else {
@@ -107,7 +107,9 @@ impl ProcessingM2C {
         (*processing_m2_c).x = processing_m2.x;
         (*processing_m2_c).g_y = processing_m2.g_y;
         (*processing_m2_c).plaintext_2 = processing_m2.plaintext_2;
-        (*processing_m2_c).c_r = processing_m2.c_r;
+        let c_r = processing_m2.c_r.as_slice();
+        assert_eq!(c_r.len(), 1, "C API only supports short C_R");
+        (*processing_m2_c).c_r = c_r[0];
     }
 }
 

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -45,11 +45,13 @@ impl PyEdhocResponder {
         &mut self,
         py: Python<'a>,
         cred_transfer: CredentialTransfer,
-        c_r: Option<u8>,
+        c_r: Option<Vec<u8>>,
         ead_2: Option<EADItem>,
     ) -> PyResult<&'a PyBytes> {
         let c_r = match c_r {
-            Some(c_r) => c_r,
+            Some(c_r) => ConnId::from_slice(c_r.as_slice()).ok_or(
+                pyo3::exceptions::PyValueError::new_err("Connection identifier out of range"),
+            )?,
             None => generate_connection_identifier_cbor(&mut default_crypto()),
         };
         let mut r = BytesP256ElemLen::default();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -126,7 +126,7 @@ impl<'a, Crypto: CryptoTrait> EdhocResponderProcessedM1<'a, Crypto> {
     pub fn prepare_message_2(
         mut self,
         cred_transfer: CredentialTransfer,
-        c_r: Option<u8>,
+        c_r: Option<ConnId>,
         ead_2: &Option<EADItem>,
     ) -> Result<(EdhocResponderWaitM3<Crypto>, BufferMessage2), EDHOCError> {
         let c_r = match c_r {
@@ -253,7 +253,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiator<Crypto> {
 
     pub fn prepare_message_1(
         mut self,
-        c_i: Option<u8>,
+        c_i: Option<ConnId>,
         ead_1: &Option<EADItem>,
     ) -> Result<(EdhocInitiatorWaitM2<Crypto>, EdhocMessageBuffer), EDHOCError> {
         let c_i = match c_i {
@@ -289,7 +289,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorWaitM2<Crypto> {
     ) -> Result<
         (
             EdhocInitiatorProcessingM2<Crypto>,
-            u8,
+            ConnId,
             CredentialRPK,
             Option<EADItem>,
         ),
@@ -399,16 +399,16 @@ impl<Crypto: CryptoTrait> EdhocInitiatorDone<Crypto> {
     }
 }
 
-pub fn generate_connection_identifier_cbor<Crypto: CryptoTrait>(crypto: &mut Crypto) -> u8 {
+pub fn generate_connection_identifier_cbor<Crypto: CryptoTrait>(crypto: &mut Crypto) -> ConnId {
     let c_i = generate_connection_identifier(crypto);
-    if c_i >= 0 && c_i <= 23 {
+    ConnId::from_int_raw(if c_i >= 0 && c_i <= 23 {
         c_i as u8 // verbatim encoding of single byte integer
     } else if c_i < 0 && c_i >= -24 {
         // negative single byte integer encoding
         CBOR_NEG_INT_1BYTE_START - 1 + c_i.unsigned_abs()
     } else {
         0
-    }
+    })
 }
 
 /// generates an identifier that can be serialized as a single CBOR integer, i.e. -24 <= x <= 23


### PR DESCRIPTION
This makes the APIs clearer and paves the way for adding support for longer C_x.

Contributes-To: https://github.com/openwsn-berkeley/lakers/issues/258

Marked as a draft while waiting for CI checks (I only did `cargo test` which usually misses some)