### PR TITLE
Expose C_I to responders

### DIFF
--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -51,7 +51,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     let valid_cred_r = credential_check_or_fetch(Some(cred_r), id_cred_r).unwrap();
     let initiator = initiator.verify_message_2(&I, cred_i, valid_cred_r)?;
 
-    let mut msg_3 = Vec::from([c_r]);
+    let mut msg_3 = Vec::from(c_r.as_cbor());
     let (mut initiator, message_3, prk_out) =
         initiator.prepare_message_3(CredentialTransfer::ByReference, &None)?;
     msg_3.extend_from_slice(message_3.as_slice());

--- a/examples/coap/src/bin/coapserver-coaphandler.rs
+++ b/examples/coap/src/bin/coapserver-coaphandler.rs
@@ -113,7 +113,7 @@ impl coap_handler::Handler for EdhocHandler {
             let message_1 =
                 &EdhocMessageBuffer::new_from_slice(&request.payload()[1..]).map_err(too_small)?;
 
-            let (responder, ead_1) =
+            let (responder, _c_i, ead_1) =
                 EdhocResponder::new(lakers_crypto::default_crypto(), &R, cred_r)
                     .process_message_1(message_1)
                     .map_err(render_error)?;

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -83,7 +83,7 @@ fn main() {
             } else {
                 // potentially message 3
                 println!("Received message 3");
-                let c_r_rcvd = request.message.payload[0];
+                let c_r_rcvd = ConnId::from_int_raw(request.message.payload[0]);
                 // FIXME let's better not *panic here
                 let responder = take_state(c_r_rcvd, &mut edhoc_connections).unwrap();
 
@@ -141,8 +141,8 @@ fn main() {
 }
 
 fn take_state<R>(
-    c_r_rcvd: u8,
-    edhoc_protocol_states: &mut Vec<(u8, R)>,
+    c_r_rcvd: ConnId,
+    edhoc_protocol_states: &mut Vec<(ConnId, R)>,
 ) -> Result<R, &'static str> {
     for (i, element) in edhoc_protocol_states.iter().enumerate() {
         let (c_r, _responder) = element;

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -48,7 +48,7 @@ fn main() {
                     .expect("wrong length");
                 let result = responder.process_message_1(&message_1);
 
-                if let Ok((responder, ead_1)) = result {
+                if let Ok((responder, _c_i, ead_1)) = result {
                     let c_r =
                         generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto());
                     let ead_2 = if let Some(ead_1) = ead_1 {

--- a/examples/lakers-no_std/src/main.rs
+++ b/examples/lakers-no_std/src/main.rs
@@ -83,8 +83,8 @@ fn main() -> ! {
     fn test_prepare_message_1() {
         let mut initiator = EdhocInitiator::new(lakers_crypto::default_crypto());
 
-        let c_i: u8 =
-            generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).into();
+        let c_i =
+            generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).as_slice();
         let message_1 = initiator.prepare_message_1(None, &None);
         assert!(message_1.is_ok());
     }

--- a/examples/lakers-no_std/src/main.rs
+++ b/examples/lakers-no_std/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> ! {
 
         let (initiator, message_1) = initiator.prepare_message_1(None, &None).unwrap();
 
-        let (responder, _ead_1) = responder.process_message_1(&message_1).unwrap();
+        let (responder, _c_i, _ead_1) = responder.process_message_1(&message_1).unwrap();
         let (responder, message_2) = responder
             .prepare_message_2(CredentialTransfer::ByReference, None, &None)
             .unwrap();

--- a/lakers-c/src/initiator.rs
+++ b/lakers-c/src/initiator.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn initiator_prepare_message_1(
     let c_i = if c_i.is_null() {
         generate_connection_identifier_cbor(crypto)
     } else {
-        *c_i
+        ConnId::from_int_raw(*c_i)
     };
 
     let ead_1 = if ead_1_c.is_null() {
@@ -108,7 +108,9 @@ pub unsafe extern "C" fn initiator_parse_message_2(
     let result = match i_parse_message_2(&state, crypto, &(*message_2)) {
         Ok((state, c_r, id_cred_r, ead_2)) => {
             ProcessingM2C::copy_into_c(state, &mut (*initiator_c).processing_m2);
-            *c_r_out = c_r;
+            let c_r = c_r.as_slice();
+            assert_eq!(c_r.len(), 1, "C API only supports short C_R");
+            *c_r_out = c_r[0];
             *id_cred_r_out = id_cred_r;
             if let Some(ead_2) = ead_2 {
                 EADItemC::copy_into_c(ead_2, ead_2_c_out);

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -86,7 +86,7 @@ impl ProcessingM2C {
             x: self.x,
             g_y: self.g_y,
             plaintext_2: self.plaintext_2,
-            c_r: self.c_r,
+            c_r: ConnId::from_int_raw(self.c_r),
             ead_2: if self.ead_2.is_null() {
                 None
             } else {
@@ -107,7 +107,9 @@ impl ProcessingM2C {
         (*processing_m2_c).x = processing_m2.x;
         (*processing_m2_c).g_y = processing_m2.g_y;
         (*processing_m2_c).plaintext_2 = processing_m2.plaintext_2;
-        (*processing_m2_c).c_r = processing_m2.c_r;
+        let c_r = processing_m2.c_r.as_slice();
+        assert_eq!(c_r.len(), 1, "C API only supports short C_R");
+        (*processing_m2_c).c_r = c_r[0];
     }
 }
 

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -33,12 +33,18 @@ impl PyEdhocResponder {
         }
     }
 
-    fn process_message_1(&mut self, message_1: Vec<u8>) -> PyResult<Option<EADItem>> {
+    fn process_message_1<'a>(
+        &mut self,
+        py: Python<'a>,
+        message_1: Vec<u8>,
+    ) -> PyResult<(&'a PyBytes, Option<EADItem>)> {
         let message_1 = EdhocMessageBuffer::new_from_slice(message_1.as_slice())?;
-        let (state, ead_1) = r_process_message_1(&self.start, &mut default_crypto(), &message_1)?;
+        let (state, c_i, ead_1) =
+            r_process_message_1(&self.start, &mut default_crypto(), &message_1)?;
         self.processing_m1 = state;
+        let c_i = PyBytes::new(py, c_i.as_slice());
 
-        Ok(ead_1)
+        Ok((c_i, ead_1))
     }
 
     fn prepare_message_2<'a>(

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -45,11 +45,13 @@ impl PyEdhocResponder {
         &mut self,
         py: Python<'a>,
         cred_transfer: CredentialTransfer,
-        c_r: Option<u8>,
+        c_r: Option<Vec<u8>>,
         ead_2: Option<EADItem>,
     ) -> PyResult<&'a PyBytes> {
         let c_r = match c_r {
-            Some(c_r) => c_r,
+            Some(c_r) => ConnId::from_slice(c_r.as_slice()).ok_or(
+                pyo3::exceptions::PyValueError::new_err("Connection identifier out of range"),
+            )?,
             None => generate_connection_identifier_cbor(&mut default_crypto()),
         };
         let mut r = BytesP256ElemLen::default();

--- a/lakers-python/test/test_ead_authz.py
+++ b/lakers-python/test/test_ead_authz.py
@@ -68,7 +68,7 @@ def test_handshake_with_authz():
     device.set_h_message_1(initiator.get_h_message_1())
 
     # responder
-    ead_1 = responder.process_message_1(message_1)
+    _c_i, ead_1 = responder.process_message_1(message_1)
     loc_w, voucher_request = authenticator.process_ead_1(ead_1, message_1)
     voucher_response = enrollment_server.handle_voucher_request(voucher_request)
     ead_2 = authenticator.prepare_ead_2(voucher_response)

--- a/lakers-python/test/test_lakers.py
+++ b/lakers-python/test/test_lakers.py
@@ -29,7 +29,7 @@ def test_handshake():
     message_1 = initiator.prepare_message_1(c_i=None, ead_1=None)
 
     # responder
-    ead_1 = responder.process_message_1(message_1)
+    _c_i, ead_1 = responder.process_message_1(message_1)
     assert ead_1 == None
     message_2 = responder.prepare_message_2(lakers.CredentialTransfer.ByReference, None, ead_1)
     assert type(message_2) == bytes

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -57,7 +57,7 @@ pub fn r_process_message_1(
     state: &ResponderStart,
     crypto: &mut impl CryptoTrait,
     message_1: &BufferMessage1,
-) -> Result<(ProcessingM1, Option<EADItem>), EDHOCError> {
+) -> Result<(ProcessingM1, ConnId, Option<EADItem>), EDHOCError> {
     // Step 1: decode message_1
     // g_x will be saved to the state
     if let Ok((method, suites_i, suites_i_len, g_x, c_i, ead_1)) = parse_message_1(message_1) {
@@ -78,6 +78,7 @@ pub fn r_process_message_1(
                         g_x,
                         h_message_1,
                     },
+                    c_i,
                     ead_1,
                 ))
             } else {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -107,8 +107,15 @@ impl<'a, Crypto: CryptoTrait> EdhocResponder<'a, Crypto> {
     pub fn process_message_1(
         mut self,
         message_1: &BufferMessage1,
-    ) -> Result<(EdhocResponderProcessedM1<'a, Crypto>, Option<EADItem>), EDHOCError> {
-        let (state, ead_1) = r_process_message_1(&self.state, &mut self.crypto, message_1)?;
+    ) -> Result<
+        (
+            EdhocResponderProcessedM1<'a, Crypto>,
+            ConnId,
+            Option<EADItem>,
+        ),
+        EDHOCError,
+    > {
+        let (state, c_i, ead_1) = r_process_message_1(&self.state, &mut self.crypto, message_1)?;
 
         Ok((
             EdhocResponderProcessedM1 {
@@ -117,6 +124,7 @@ impl<'a, Crypto: CryptoTrait> EdhocResponder<'a, Crypto> {
                 cred_r: self.cred_r,
                 crypto: self.crypto,
             },
+            c_i,
             ead_1,
         ))
     }
@@ -567,7 +575,7 @@ mod test {
         // ---- end initiator handling
 
         // ---- begin responder handling
-        let (responder, _ead_1) = responder.process_message_1(&message_1).unwrap();
+        let (responder, _c_i, _ead_1) = responder.process_message_1(&message_1).unwrap();
         // if ead_1: process ead_1
         // if needed: prepare ead_2
         let (responder, message_2) = responder
@@ -681,7 +689,7 @@ mod test_authz {
         let (initiator, message_1) = initiator.prepare_message_1(None, &Some(ead_1)).unwrap();
         device.set_h_message_1(initiator.state.h_message_1.clone());
 
-        let (responder, ead_1) = responder.process_message_1(&message_1).unwrap();
+        let (responder, _c_i, ead_1) = responder.process_message_1(&message_1).unwrap();
         let ead_2 = if let Some(ead_1) = ead_1 {
             let (authenticator, _loc_w, voucher_request) =
                 authenticator.process_ead_1(&ead_1, &message_1).unwrap();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -126,7 +126,7 @@ impl<'a, Crypto: CryptoTrait> EdhocResponderProcessedM1<'a, Crypto> {
     pub fn prepare_message_2(
         mut self,
         cred_transfer: CredentialTransfer,
-        c_r: Option<u8>,
+        c_r: Option<ConnId>,
         ead_2: &Option<EADItem>,
     ) -> Result<(EdhocResponderWaitM3<Crypto>, BufferMessage2), EDHOCError> {
         let c_r = match c_r {
@@ -253,7 +253,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiator<Crypto> {
 
     pub fn prepare_message_1(
         mut self,
-        c_i: Option<u8>,
+        c_i: Option<ConnId>,
         ead_1: &Option<EADItem>,
     ) -> Result<(EdhocInitiatorWaitM2<Crypto>, EdhocMessageBuffer), EDHOCError> {
         let c_i = match c_i {
@@ -289,7 +289,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorWaitM2<Crypto> {
     ) -> Result<
         (
             EdhocInitiatorProcessingM2<Crypto>,
-            u8,
+            ConnId,
             CredentialRPK,
             Option<EADItem>,
         ),
@@ -399,16 +399,16 @@ impl<Crypto: CryptoTrait> EdhocInitiatorDone<Crypto> {
     }
 }
 
-pub fn generate_connection_identifier_cbor<Crypto: CryptoTrait>(crypto: &mut Crypto) -> u8 {
+pub fn generate_connection_identifier_cbor<Crypto: CryptoTrait>(crypto: &mut Crypto) -> ConnId {
     let c_i = generate_connection_identifier(crypto);
-    if c_i >= 0 && c_i <= 23 {
+    ConnId::from_int_raw(if c_i >= 0 && c_i <= 23 {
         c_i as u8 // verbatim encoding of single byte integer
     } else if c_i < 0 && c_i >= -24 {
         // negative single byte integer encoding
         CBOR_NEG_INT_1BYTE_START - 1 + c_i.unsigned_abs()
     } else {
         0
-    }
+    })
 }
 
 /// generates an identifier that can be serialized as a single CBOR integer, i.e. -24 <= x <= 23


### PR DESCRIPTION
Depends-On: #260 (therefore, just check the top commit)

Closes: #258

On the Python side, this follows the convention established in #260 to represent ConnId as bytes instead of an integer (so we won't need an API change there once ConnId can get larger)