### PR TITLE
r_parse_message_3: Tolerate unparsable credential-by-value

### DIFF
--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -84,14 +84,11 @@ impl PyEdhocInitiator {
     pub fn verify_message_2(
         &mut self,
         i: Vec<u8>,
-        cred_i: Vec<u8>,
-        valid_cred_r: Vec<u8>,
+        cred_i: super::AutoCredentialRPK,
+        valid_cred_r: super::AutoCredentialRPK,
     ) -> PyResult<()> {
-        let cred_i =
-            CredentialRPK::new(EdhocMessageBuffer::new_from_slice(&cred_i.as_slice()).unwrap())?;
-        let valid_cred_r = CredentialRPK::new(
-            EdhocMessageBuffer::new_from_slice(&valid_cred_r.as_slice()).unwrap(),
-        )?;
+        let cred_i = cred_i.to_credential()?;
+        let valid_cred_r = valid_cred_r.to_credential()?;
 
         match i_verify_message_2(
             &self.processing_m2,

--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -70,6 +70,7 @@ fn lakers_python(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<responder::PyEdhocResponder>()?;
     m.add_class::<lakers::CredentialTransfer>()?;
     m.add_class::<lakers::EADItem>()?;
+    m.add_class::<lakers::CredentialRPK>()?;
     // ead-authz items
     m.add_class::<ead_authz::PyAuthzDevice>()?;
     m.add_class::<ead_authz::PyAuthzAutenticator>()?;

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -176,6 +176,8 @@ pub fn r_parse_message_3(
                     if let Ok(parsed_rpk) = CredentialRPK::new(buffer) {
                         parsed_rpk
                     } else {
+                        // This is incomplete, and the application will need to fill in the gaps --
+                        // just as in the CompactKid case the CredentialRPK is also incomplete.
                         CredentialRPK {
                             value: buffer,
                             public_key: Default::default(),

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -173,7 +173,15 @@ pub fn r_parse_message_3(
                     let Ok(buffer) = EdhocMessageBuffer::new_from_slice(cred) else {
                         return Err(EDHOCError::ParsingError);
                     };
-                    CredentialRPK::new(buffer)?
+                    if let Ok(parsed_rpk) = CredentialRPK::new(buffer) {
+                        parsed_rpk
+                    } else {
+                        CredentialRPK {
+                            value: buffer,
+                            public_key: Default::default(),
+                            kid: Default::default(),
+                        }
+                    }
                 }
             };
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -13,10 +13,11 @@ categories.workspace = true
 
 [dependencies]
 pyo3 = { version = "0.20.2", features = ["extension-module"], optional = true }
+hex = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 hexlit = "0.5.3"
 
 [features]
 default = [  ]
-python-bindings = ["pyo3"]
+python-bindings = ["pyo3", "hex"]

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "python-bindings", pyclass)]
 #[repr(C)]
 pub struct CredentialRPK {
     pub value: EdhocMessageBuffer,

--- a/shared/src/python_bindings.rs
+++ b/shared/src/python_bindings.rs
@@ -82,6 +82,15 @@ impl CredentialRPK {
         }
     }
 
+    fn __repr__(&self) -> String {
+        format!(
+            "CredentialRpk(bytes.fromhex('{}'), public_key=bytes.fromhex('{}'), kid={})",
+            hex::encode(self.value.as_slice()),
+            hex::encode(self.public_key),
+            self.kid,
+        )
+    }
+
     fn value<'a>(&self, py: Python<'a>) -> &'a PyBytes {
         PyBytes::new(py, self.value.as_slice())
     }


### PR DESCRIPTION
This enables using CWTs as values, provided that in the same step as where the user expands a credential-by-kid into a full credential, they also parse any non-CCS (or differently shaped CCS) values such as a CWT into the credential (left as it is), the key and the key ID.

This builds on #270 and addresses its usability caveat described in https://github.com/openwsn-berkeley/lakers/issues/269#issuecomment-2113512458

I still think we may want to elaborate the CredentialRpk type into differentiating at the type level whether it is valid (has KID, key and credential) or just partial (in the shapes "we parsed it already, it is valid", "we only have the KID" and "we only have the credential value but no keys", possibly others in the future), but that's API rework, and this enables things with the API as we have it.