### PR TITLE
Release: bump versions to 0.6.1 (rust) and 0.3.2 (python)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/openwsn-berkeley/lakers/"
 license = "BSD-3-Clause"
 readme = "shared/README.md"
@@ -39,16 +39,16 @@ categories = [ "no-std::no-alloc", "network-programming", "embedded" ]
 
 [workspace.dependencies]
 
-lakers-shared = { package = "lakers-shared", path = "shared/", version = "^0.6.0" }
+lakers-shared = { package = "lakers-shared", path = "shared/", version = "^0.6.1" }
 
-lakers-ead-authz = { package = "lakers-ead-authz", path = "ead/lakers-ead-authz/", version = "^0.6.0" }
+lakers-ead-authz = { package = "lakers-ead-authz", path = "ead/lakers-ead-authz/", version = "^0.6.1" }
 
 lakers-crypto = { path = "crypto/" }
 lakers-crypto-cryptocell310 = { path = "crypto/lakers-crypto-cryptocell310-sys/" }
 lakers-crypto-psa = { path = "crypto/lakers-crypto-psa/" }
-lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.6.0" }
+lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.6.1" }
 
-lakers = { package = "lakers", path = "lib/", version = "^0.6.0", default-features = false }
+lakers = { package = "lakers", path = "lib/", version = "^0.6.1", default-features = false }
 
 [patch.crates-io]
 psa-crypto = { git = "https://github.com/malishav/rust-psa-crypto", branch = "baremetal" }

--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lakers-python" # this will be the name of the package on pypi
 edition = "2021"
-version ="0.3.1"
+version ="0.3.2"
 repository.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
Fixes #285 