### PR TITLE
More Python targets: 3.13, pypy3.10

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -20,9 +20,11 @@ jobs:
             macos-13, # latest non-beta version
         ] # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
         python-version: [
+            'pypy3.10',
             '3.10',
             '3.11',
             '3.12',
+            '3.13',
         ] # see https://devguide.python.org/versions/
 
     steps:
@@ -37,6 +39,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # currently for 3.13; could be disabled when 3.13 is out until 3.14 is being tested
+          allow-prereleases: true
           architecture: x64
 
       - name: Install maturin


### PR DESCRIPTION
On top of #290, this adds pypy3.10 and Python 3.13 to the list of build wheels.

Closes: #288

Feel free to disregard this as "too much CI time" if you feel it doesn't carry its own weight – that'd be a fine policy which I can then reference in the aiocoap CI setup as the reason why rust needs to be installed on those.