### PR TITLE
Release: rust 0.6.2 and python 0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 repository = "https://github.com/openwsn-berkeley/lakers/"
 license = "BSD-3-Clause"
 readme = "shared/README.md"
@@ -39,16 +39,16 @@ categories = [ "no-std::no-alloc", "network-programming", "embedded" ]
 
 [workspace.dependencies]
 
-lakers-shared = { package = "lakers-shared", path = "shared/", version = "^0.6.1" }
+lakers-shared = { package = "lakers-shared", path = "shared/", version = "^0.6.2" }
 
-lakers-ead-authz = { package = "lakers-ead-authz", path = "ead/lakers-ead-authz/", version = "^0.6.1" }
+lakers-ead-authz = { package = "lakers-ead-authz", path = "ead/lakers-ead-authz/", version = "^0.6.2" }
 
 lakers-crypto = { path = "crypto/" }
 lakers-crypto-cryptocell310 = { path = "crypto/lakers-crypto-cryptocell310-sys/" }
 lakers-crypto-psa = { path = "crypto/lakers-crypto-psa/" }
-lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.6.1" }
+lakers-crypto-rustcrypto = { package = "lakers-crypto-rustcrypto", path = "crypto/lakers-crypto-rustcrypto/", version = "^0.6.2" }
 
-lakers = { package = "lakers", path = "lib/", version = "^0.6.1", default-features = false }
+lakers = { package = "lakers", path = "lib/", version = "^0.6.2", default-features = false }
 
 [patch.crates-io]
 psa-crypto = { git = "https://github.com/malishav/rust-psa-crypto", branch = "baremetal" }

--- a/examples/lakers-no_std/rust-toolchain
+++ b/examples/lakers-no_std/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+../../rust-toolchain

--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lakers-python" # this will be the name of the package on pypi
 edition = "2021"
-version ="0.3.2"
+version ="0.3.3"
 repository.workspace = true
 license.workspace = true
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2024-06-22


### PR DESCRIPTION
includes bug fixes with python wheel distribution
and in turn facilitates integration with libraries that depend on lakers-python, such as aiocoap

actually, the rust side doesn't have updates,
but since the triggers to publish python wheels are on github actions, I am just bumping all the versions