### PR TITLE
Use defmt or log

### DIFF
--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lakers = { package = "lakers", path = "../../lib" }
+lakers = { package = "lakers", path = "../../lib", features = [ "log" ] }
 lakers-ead-authz = { path = "../../ead/lakers-ead-authz" }
 lakers-crypto = { path = "../../crypto/", features = [ "rustcrypto" ] }
 hexlit = "0.5.3"

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -20,5 +20,13 @@ coap-handler-implementations = "0.5"
 coap-numbers = "0.2.3"
 coap-message-utils = "0.3.1"
 
+# Logging
 env_logger = "0.11.3"
-log = "0.4"
+defmt-or-log = { version = "0.2.1", default-features = false }
+log = { version = "0.4", optional = true }
+defmt = { version = "0.3", optional = true }
+
+[features]
+default = ["log"]
+defmt = ["dep:defmt"]
+log = ["dep:log"]

--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -1,8 +1,8 @@
 use coap::CoAPClient;
 use coap_lite::ResponseType;
+use defmt_or_log::info;
 use hexlit::hex;
 use lakers::*;
-use log::*;
 use std::time::Duration;
 
 const _ID_CRED_I: &[u8] = &hex!("a104412b");

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -1,8 +1,8 @@
 use coap_lite::{CoapRequest, Packet, ResponseType};
+use defmt_or_log::info;
 use hexlit::hex;
 use lakers::*;
 use lakers_ead_authz::{ZeroTouchAuthenticator, ZeroTouchServer};
-use log::*;
 use std::net::UdpSocket;
 
 const ID_CRED_I: &[u8] = &hex!("a104412b");

--- a/examples/lakers-nrf52840/Cargo.toml
+++ b/examples/lakers-nrf52840/Cargo.toml
@@ -15,7 +15,7 @@ embassy-time = { git =  "https://github.com/embassy-rs/embassy", branch = "main"
 embassy-nrf = { git =  "https://github.com/embassy-rs/embassy", branch = "main", features = ["defmt", "nrf52840", "time-driver-rtc1", "gpiote", "unstable-pac", "time"] }
 
 # lakers
-lakers = { package = "lakers", path = "../../lib", default-features = false }
+lakers = { package = "lakers", path = "../../lib", features = [ "defmt" ] }
 lakers-crypto = { path = "../../crypto", default-features = false }
 
 # misc

--- a/examples/lakers-nrf52840/README.md
+++ b/examples/lakers-nrf52840/README.md
@@ -21,3 +21,5 @@ You may want to prefix the commands above with e.g. PROBE_RS_PROBE=1366:1051:001
 You can get the name of your probes by running:
 
     probe-rs list
+
+You can enhance debugging by passing environment variables such as `DEFMT_LOG=trace`."

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,9 @@ categories.workspace = true
 [dependencies]
 lakers-shared.workspace = true
 
-log = "0.4"
+defmt-or-log = { version = "0.2.1", default-features = false }
+log = { version = "0.4", optional = true }
+defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
 lakers-ead-authz = { workspace = true }
@@ -21,9 +23,11 @@ hexlit = "0.5.3"
 
 [features]
 # NOTE: the ead features are just needed for multiplexing tests
-default = [ "test-ead-none" ]
+default = [ "test-ead-none", "log" ]
 test-ead-none = [ ]
 test-ead-authz = [ ]
+defmt = ["dep:defmt"]
+log = ["dep:log"]
 
 [lib]
 crate-type = ["rlib"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ hexlit = "0.5.3"
 
 [features]
 # NOTE: the ead features are just needed for multiplexing tests
-default = [ "test-ead-none", "log" ]
+default = [ "test-ead-none" ]
 test-ead-none = [ ]
 test-ead-authz = [ ]
 defmt = ["dep:defmt"]

--- a/lib/README.md
+++ b/lib/README.md
@@ -123,3 +123,22 @@ Its main members are:
 - `lakers-c`: Provides a foreign function interface that enables using `lakers` from C code.
 - `lakers-python`: API for using `lakers` in Python.
 - `examples`: Example applications that demonstrate how to use the library.
+
+## Example: using logs
+Logs can be used in both native and embedded applications. Once configured in an application, both can be controlled via environment variables:
+
+- on native, set `RUST_LOG` to control Rust's built-in `log` facility
+- on embedded, set `DEFMT_LOG` to control the [defmt](https://github.com/knurling-rs/defmt) crate
+
+The selection of `log` or `defmt` is handled internally by the [defmt-or-log](https://github.com/t-moe/defmt-or-log) crate.
+
+For example, `examples/lakers-nrf52840` is configured to use `defmt`. To globally enable logs at level `trace`:
+```bash
+DEFMT_LOG=trace cargo run --bin initiator
+```
+
+Different log levels can also be set per crate or module.
+Here's how to globally set logs to level `trace`, while restricting `lakers` to level `info`:
+```bash
+DEFMT_LOG=trace,lakers=info cargo run --bin initiator
+```

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,9 +15,7 @@
 //! [EDHOC]: https://datatracker.ietf.org/doc/html/rfc9528
 #![cfg_attr(not(test), no_std)]
 
-// use defmt_or_log::*; // FIXME: still not working
-use log::trace;
-
+use defmt_or_log::trace;
 pub use {lakers_shared::Crypto as CryptoTrait, lakers_shared::*};
 
 #[cfg(all(feature = "ead-authz", test))]

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,7 +14,9 @@ categories.workspace = true
 [dependencies]
 pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 hex = { version = "0.4.3", optional = true }
-log = "0.4"
+defmt-or-log = { version = "0.2.1", default-features = false }
+log = { version = "0.4", optional = true }
+defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
 hexlit = "0.5.3"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -16,7 +16,7 @@ pub use edhoc_parser::*;
 pub use helpers::*;
 
 use core::num::NonZeroI16;
-use log::trace;
+use defmt_or_log::trace;
 
 mod crypto;
 pub use crypto::Crypto;


### PR DESCRIPTION
This PR addresses issue #280 . It introduces two new optional dependencies: `defmt` and `defmt-or-log`. Additionally, it makes the `log` dependency optional.

The purpose of this change is to allow users to specify either `log` or `defmt` as a feature for the lib. This flexibility should simplify debugging the lib on microcontrollers.

As this is my first PR for this library, I am open to feedback and suggestions! Please let me know if any changes are needed.