### PR TITLE
Fix the compilation target of the lakers_nrf52840 example to Cortex-M4F using hard floats

### DIFF
--- a/examples/lakers-nrf52840/.cargo/config.toml
+++ b/examples/lakers-nrf52840/.cargo/config.toml
@@ -3,7 +3,7 @@
 runner = "probe-rs run --chip nRF52840_xxAA"
 
 [build]
-target = "thumbv7em-none-eabi"
+target = "thumbv7em-none-eabihf"
 
 [env]
 DEFMT_LOG = "trace"

--- a/examples/lakers-nrf52840/Cargo.toml
+++ b/examples/lakers-nrf52840/Cargo.toml
@@ -34,7 +34,7 @@ cortex-m-rt = "0.7.0"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
 [features]
-default = [ "crypto-psa", "ead-none" ]
+default = [ "crypto-cryptocell310", "ead-none" ]
 crypto-cryptocell310 = [ "lakers-crypto/cryptocell310" ]
 crypto-psa = [ "lakers-crypto/psa-baremetal" ]
 ead-none = [ ]


### PR DESCRIPTION
This fixes the issue of mismatched binary of Cryptocell310 and the nRF compilation target, making cryptocell310-based backend work in this example, as well. Using now the cryptocell310 backend by default.

Fixes #313 