### PR TITLE
Support long C_x

### DIFF
--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -511,7 +511,7 @@ fn encode_message_1(
     output.content[2 + raw_suites_len] = P256_ELEM_LEN as u8; // length of the byte string
     output.content[3 + raw_suites_len..3 + raw_suites_len + P256_ELEM_LEN]
         .copy_from_slice(&g_x[..]);
-    let c_i = c_i.as_slice();
+    let c_i = c_i.as_cbor();
     output.len = 3 + raw_suites_len + P256_ELEM_LEN + c_i.len();
     output.content[3 + raw_suites_len + P256_ELEM_LEN..][..c_i.len()].copy_from_slice(c_i);
 
@@ -858,7 +858,7 @@ fn encode_plaintext_2(
     ead_2: &Option<EADItem>,
 ) -> Result<BufferPlaintext2, EDHOCError> {
     let mut plaintext_2: BufferPlaintext2 = BufferPlaintext2::new();
-    let c_r = c_r.as_slice();
+    let c_r = c_r.as_cbor();
 
     plaintext_2
         .extend_from_slice(c_r)

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1096,8 +1096,9 @@ mod tests {
     // invalid test vectors, should result in a parsing error
     const MESSAGE_1_INVALID_ARRAY_TV: &str =
         "8403025820741a13d7ba048fbb615e94386aa3b61bea5b3d8f65f32620b749bee8d278efa90e";
+    // This is invalid because the h'0e' byte string is a text string instead
     const MESSAGE_1_INVALID_C_I_TV: &str =
-        "03025820741a13d7ba048fbb615e94386aa3b61bea5b3d8f65f32620b749bee8d278efa9410e";
+        "03025820741a13d7ba048fbb615e94386aa3b61bea5b3d8f65f32620b749bee8d278efa9610e";
     const MESSAGE_1_INVALID_CIPHERSUITE_TV: &str =
         "0381025820741a13d7ba048fbb615e94386aa3b61bea5b3d8f65f32620b749bee8d278efa90e";
     const MESSAGE_1_INVALID_TEXT_EPHEMERAL_KEY_TV: &str =

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -776,7 +776,7 @@ fn encode_kdf_context(
     let mut output: BytesMaxContextBuffer = [0x00; MAX_KDF_CONTEXT_LEN];
 
     let mut output_len = if let Some(c_r) = c_r {
-        let c_r = c_r.as_slice();
+        let c_r = c_r.as_cbor();
         output[..c_r.len()].copy_from_slice(c_r);
         c_r.len()
     } else {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -243,19 +243,20 @@ impl ConnId {
     /// assert!(long.as_slice() == &[0x12, 0x34]);
     /// ```
     pub fn from_slice(input: &[u8]) -> Option<Self> {
-        let mut s = [0; MAX_CONNID_ENCODED_LEN];
-        if let &[single_byte] = input {
-            if matches!(
-                ConnIdType::classify(single_byte),
-                Some(ConnIdType::SingleByte)
-            ) {
-                s[0] = single_byte;
-                return Some(Self(s));
+        if input.len() > MAX_CONNID_ENCODED_LEN - 1 {
+            None
+        } else {
+            let mut s = [0; MAX_CONNID_ENCODED_LEN];
+            if input.len() == 1
+                && matches!(ConnIdType::classify(input[0]), Some(ConnIdType::SingleByte))
+            {
+                s[0] = input[0];
+            } else {
+                s[0] = input.len() as u8 | 0x40;
+                s[1..1 + input.len()].copy_from_slice(input);
             }
+            Some(Self(s))
         }
-        s[0] = input.len() as u8 | 0x40;
-        s.get_mut(1..1 + input.len())?.copy_from_slice(input);
-        Some(Self(s))
     }
 }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -92,7 +92,12 @@ pub const MAX_EAD_SIZE_LEN: usize = SCALE_FACTOR * 64;
 /// Maximum length of a [`ConnId`] (`C_x`).
 ///
 /// This length includes the leading CBOR encoding byte(s).
-const MAX_CONNID_ENCODED_LEN: usize = 8;
+// If ints had a const `.clamp()` feature, this could be (8 * SCALE_FACTOR).clamp(1, 23).
+const MAX_CONNID_ENCODED_LEN: usize = if cfg!(feature = "quadruple_sizes") {
+    24
+} else {
+    8
+};
 
 pub type BytesSuites = [u8; SUITES_LEN];
 pub type BytesSupportedSuites = [u8; SUPPORTED_SUITES_LEN];


### PR DESCRIPTION
Closes: https://github.com/openwsn-berkeley/lakers/issues/258

This is a straightforward change and relatively complete; noteworthy points are:

* On some parts that I don't usually touch, things were not changed -- they should keep working, but they may still only support the short identifiers.
  Grep for `from_int_raw` to see all possible places; in particular, I known of the C API, and of the automatic generation of identifiers.
* There are unit tests in the docs, and I enabled the previously disabled tests that planned ahead for this and things just do check alright. There are no new integration tests, but I don't know whether we need any. I tested things from aiocoap, and things worked fine; I can still try an interop test with Marco later this week.
* The backing data for identifiers is an interesting thing because it's an owned small array that has no length information. CBOR is self-delimited, and I'm making use of that, thus fitting the 7 byte sensible string length (typical OSCORE KIDs are up to 7 byte) in 8 byte of RAM. The type describes its invariant, and explicitly panics in a place. I'd guess that that's just one of the panics where hax could show that no safe operation on that type will ever get it in a state where that invariant is violated, but I know too little about it to tell whether it already does that, or whether it'll need some handholding, or whether it doesn't matter anyway.