### PR TITLE
python: Make safer to use

### DIFF
--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -12,6 +12,28 @@ mod ead_authz;
 mod initiator;
 mod responder;
 
+/// Error raised when operations on a Python object did not happen in the sequence in which they
+/// were intended.
+///
+/// This currently has no more detailed response because for every situation this can occur in,
+/// there are different possible explainations that we can't get across easily in a single message.
+/// For example, if `responder.processing_m1` is absent, that can be either because no message 1
+/// was processed into it yet, or because message 2 was already generated.
+#[derive(Debug)]
+pub(crate) struct StateMismatch;
+
+impl std::error::Error for StateMismatch {}
+impl std::fmt::Display for StateMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Type state mismatch")
+    }
+}
+impl From<StateMismatch> for PyErr {
+    fn from(err: StateMismatch) -> PyErr {
+        pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
+    }
+}
+
 // NOTE: throughout this implementation, we use Vec<u8> for incoming byte lists and PyBytes for outgoing byte lists.
 // This is because the incoming lists of bytes are automatically converted to `Vec<u8>` by pyo3,
 // but the outgoing ones must be explicitly converted to `PyBytes`.

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -3,15 +3,17 @@ use lakers_crypto::{default_crypto, CryptoTrait};
 use log::trace;
 use pyo3::{prelude::*, types::PyBytes};
 
+use super::StateMismatch;
+
 #[pyclass(name = "EdhocResponder")]
 pub struct PyEdhocResponder {
     r: Vec<u8>,
     cred_r: Credential,
-    start: ResponderStart,
-    processing_m1: ProcessingM1,
-    wait_m3: WaitM3,
-    processing_m3: ProcessingM3,
-    completed: Completed,
+    start: Option<ResponderStart>,
+    processing_m1: Option<ProcessingM1>,
+    wait_m3: Option<WaitM3>,
+    processing_m3: Option<ProcessingM3>,
+    completed: Option<Completed>,
 }
 
 #[pymethods]
@@ -26,15 +28,15 @@ impl PyEdhocResponder {
         Ok(Self {
             r,
             cred_r,
-            start: ResponderStart {
+            start: Some(ResponderStart {
                 method: EDHOCMethod::StatStat.into(),
                 y,
                 g_y,
-            },
-            processing_m1: ProcessingM1::default(),
-            wait_m3: WaitM3::default(),
-            processing_m3: ProcessingM3::default(),
-            completed: Completed::default(),
+            }),
+            processing_m1: None,
+            wait_m3: None,
+            processing_m3: None,
+            completed: None,
         })
     }
 
@@ -44,9 +46,12 @@ impl PyEdhocResponder {
         message_1: Vec<u8>,
     ) -> PyResult<(Bound<'a, PyBytes>, Option<EADItem>)> {
         let message_1 = EdhocMessageBuffer::new_from_slice(message_1.as_slice())?;
-        let (state, c_i, ead_1) =
-            r_process_message_1(&self.start, &mut default_crypto(), &message_1)?;
-        self.processing_m1 = state;
+        let (state, c_i, ead_1) = r_process_message_1(
+            &self.start.take().ok_or(StateMismatch)?,
+            &mut default_crypto(),
+            &message_1,
+        )?;
+        self.processing_m1 = Some(state);
         let c_i = PyBytes::new_bound(py, c_i.as_slice());
 
         Ok((c_i, ead_1))
@@ -73,7 +78,7 @@ impl PyEdhocResponder {
         r.copy_from_slice(self.r.as_slice());
 
         match r_prepare_message_2(
-            &self.processing_m1,
+            self.processing_m1.as_ref().ok_or(StateMismatch)?,
             &mut default_crypto(),
             self.cred_r,
             &r,
@@ -82,7 +87,7 @@ impl PyEdhocResponder {
             &ead_2,
         ) {
             Ok((state, message_2)) => {
-                self.wait_m3 = state;
+                self.wait_m3 = Some(state);
                 Ok(PyBytes::new_bound(py, message_2.as_slice()))
             }
             Err(error) => Err(error.into()),
@@ -95,9 +100,13 @@ impl PyEdhocResponder {
         message_3: Vec<u8>,
     ) -> PyResult<(Bound<'a, PyBytes>, Option<EADItem>)> {
         let message_3 = EdhocMessageBuffer::new_from_slice(message_3.as_slice())?;
-        match r_parse_message_3(&mut self.wait_m3, &mut default_crypto(), &message_3) {
+        match r_parse_message_3(
+            &mut self.wait_m3.take().ok_or(StateMismatch)?,
+            &mut default_crypto(),
+            &message_3,
+        ) {
             Ok((state, id_cred_i, ead_3)) => {
-                self.processing_m3 = state;
+                self.processing_m3 = Some(state);
                 Ok((PyBytes::new_bound(py, id_cred_i.bytes.as_slice()), ead_3))
             }
             Err(error) => Err(error.into()),
@@ -110,9 +119,13 @@ impl PyEdhocResponder {
         valid_cred_i: super::AutoCredential,
     ) -> PyResult<Bound<'a, PyBytes>> {
         let valid_cred_i = valid_cred_i.to_credential()?;
-        match r_verify_message_3(&mut self.processing_m3, &mut default_crypto(), valid_cred_i) {
+        match r_verify_message_3(
+            &mut self.processing_m3.take().ok_or(StateMismatch)?,
+            &mut default_crypto(),
+            valid_cred_i,
+        ) {
             Ok((state, prk_out)) => {
-                self.completed = state;
+                self.completed = Some(state);
                 Ok(PyBytes::new_bound(py, prk_out.as_slice()))
             }
             Err(error) => Err(error.into()),
@@ -130,7 +143,7 @@ impl PyEdhocResponder {
         context_buf[..context.len()].copy_from_slice(context.as_slice());
 
         let res = edhoc_exporter(
-            &self.completed,
+            self.completed.as_ref().ok_or(StateMismatch)?,
             &mut default_crypto(),
             label,
             &context_buf,
@@ -149,7 +162,7 @@ impl PyEdhocResponder {
         context_buf[..context.len()].copy_from_slice(context.as_slice());
 
         let res = edhoc_key_update(
-            &mut self.completed,
+            self.completed.as_mut().ok_or(StateMismatch)?,
             &mut default_crypto(),
             &context_buf,
             context.len(),


### PR DESCRIPTION
Previously, a call to `.edhoc_exporter()` would happily have produced exports from the all-zero key material.

This would have prevented the hiccup I ran into around https://github.com/openwsn-berkeley/lakers/pull/312#issuecomment-2454779410.

The present change ensures that attempting to run the EDHOC exporter results in a runtime error. aiocoap's tests still pass with it.

I'd prefer to go further, making the initiator start item also an option, or making this all into an enum, or even just using the high-level API, but this way at least we avoid inadvertently poking into data that should already be gone (which is something the high-level API would also ensure we don't do). Also I think that almost none of those items should implement Default. But let's do this here first and take it incrementally.

CC'ing @ElsaLopez133 (why can't I ask you to be a reviewer?) for review and because this might cause subtle (but easy to resolve) breakage with PR #312