### PR TITLE
IdCred enhancements

### DIFF
--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -39,9 +39,18 @@ impl From<u8> for IdCredType {
     }
 }
 
-/// A value of ID_CRED_x: a credential identifier
+/// A value of ID_CRED_x: a credential identifier.
 ///
 /// Possible values include key IDs, credentials by value and others.
+///
+/// ```rust
+/// # use hexlit::hex;
+/// # use lakers_shared::IdCred;
+/// let short_kid = IdCred::from_encoded_value(&hex!("17" /* 23 */)).unwrap();
+/// assert_eq!(short_kid.as_full_value(), &hex!("a1044117" /* { 4: h'17' } */));
+/// let long_kid = IdCred::from_encoded_value(&hex!("4161" /* 'a' */)).unwrap();
+/// assert_eq!(long_kid.as_full_value(), &hex!("a1044161" /* { 4: 'a' } */));
+/// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(C)]
 pub struct IdCred {

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -92,7 +92,7 @@ impl IdCred {
                 bytes
             }
             // CCS by value
-            &[0xa1, KCSS_LABEL, ..] => BufferIdCred::new_from_slice(value)
+            &[0xa1, KCCS_LABEL, ..] => BufferIdCred::new_from_slice(value)
                 .map_err(|_| EDHOCError::CredentialTooLongError)?,
             _ => return Err(EDHOCError::ParsingError),
         };
@@ -313,7 +313,7 @@ impl Credential {
                 let mut id_cred = IdCred::new();
                 id_cred
                     .bytes
-                    .extend_from_slice(&[CBOR_MAJOR_MAP + 1, KCSS_LABEL])
+                    .extend_from_slice(&[CBOR_MAJOR_MAP + 1, KCCS_LABEL])
                     .map_err(|_| EDHOCError::CredentialTooLongError)?;
                 id_cred
                     .bytes

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -46,10 +46,10 @@ impl From<u8> for IdCredType {
 /// ```rust
 /// # use hexlit::hex;
 /// # use lakers_shared::IdCred;
-/// let short_kid = IdCred::from_encoded_value(&hex!("17" /* 23 */)).unwrap();
-/// assert_eq!(short_kid.as_full_value(), &hex!("a1044117" /* { 4: h'17' } */));
-/// let long_kid = IdCred::from_encoded_value(&hex!("4161" /* 'a' */)).unwrap();
-/// assert_eq!(long_kid.as_full_value(), &hex!("a1044161" /* { 4: 'a' } */));
+/// let short_kid = IdCred::from_encoded_value(&hex!("17")).unwrap(); // 23
+/// assert_eq!(short_kid.as_full_value(), &hex!("a1044117")); // {4: h'17'}
+/// let long_kid = IdCred::from_encoded_value(&hex!("4161")).unwrap(); // 'a'
+/// assert_eq!(long_kid.as_full_value(), &hex!("a1044161")); // {4: 'a'}
 /// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(C)]

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -83,7 +83,7 @@ impl IdCred {
                     .map_err(|_| EDHOCError::CredentialTooLongError)? // TODO: how to avoid map_err overuse?
             }
             // kid that has been encoded as CBOR byte string
-            &[0x41, x, ..] if !Self::bstr_representable_as_int(x) => {
+            &[0x41, x] if !Self::bstr_representable_as_int(x) => {
                 let mut bytes = BufferIdCred::new_from_slice(&[0xa1, KID_LABEL])
                     .map_err(|_| EDHOCError::CredentialTooLongError)?;
                 bytes

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -82,7 +82,9 @@ pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bst
 						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
 						    1; // length as u8
 
-pub const KCSS_LABEL: u8 = 14;
+pub const KCCS_LABEL: u8 = 14;
+#[deprecated(note = "Typo for KCCS_LABEL")]
+pub const KCSS_LABEL: u8 = KCCS_LABEL;
 pub const KID_LABEL: u8 = 4;
 
 pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0


### PR DESCRIPTION
Some small fixes I found when updating Ariel OS to use the latest lakers:

* Some documentation on how IdCred is used would have helped, so I added an example that doubles as a doctest.
* Implementing that I found a typo (KCSS instead of KCCS); the fix is API compatible by deprecating the old version.
* The from_encoded_value constructor accepted some values that look like KIDs but are really longer. It may be a good idea to accept non-1-byte- KIDs, but this PR is designed for "all no-brainers so let's just merge it". I'm happy to provide longer KID support in there, but I don't know whether there's a limit on KID lengths in other places (won't hurt for this function to support more, though).
  [edit] Note that the way it is used internally (eg. decode_plaintext_3), the length is pre-checked to be correct due to `decoder.any_as_encoded()`, but that also means we're doing double work – still, a public function should do proper error handling.