### PR TITLE
Change API for EAD items to support large numbers

### DIFF
--- a/ead/lakers-ead-authz/src/lib.rs
+++ b/ead/lakers-ead-authz/src/lib.rs
@@ -12,7 +12,7 @@ pub use device::{ZeroTouchDevice, ZeroTouchDeviceDone, ZeroTouchDeviceWaitEAD2};
 pub use server::{ZeroTouchServer, ZeroTouchServerUserAcl};
 
 pub mod consts {
-    pub const EAD_AUTHZ_LABEL: u8 = 0x1; // NOTE: in lake-authz-draft-01 it is still TBD1
+    pub const EAD_AUTHZ_LABEL: u16 = 0x1; // NOTE: in lake-authz-draft-01 it is still TBD1
     pub const EAD_AUTHZ_INFO_K_1_LABEL: u8 = 0x0;
     pub const EAD_AUTHZ_INFO_IV_1_LABEL: u8 = 0x1;
     pub const EAD_AUTHZ_ENC_STRUCTURE_LEN: usize = 2 + 8 + 3;

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -24,7 +24,7 @@ static HEAP: Heap = Heap::empty();
 #[derive(Default, Clone, Debug)]
 #[repr(C)]
 pub struct EADItemC {
-    pub label: u8,
+    pub label: u16,
     pub is_critical: bool,
     pub value: EdhocMessageBuffer,
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -635,7 +635,12 @@ impl TryInto<EdhocMessageBuffer> for &[u8] {
 #[cfg_attr(feature = "python-bindings", pyclass)]
 #[derive(Clone, Debug)]
 pub struct EADItem {
-    pub label: u8,
+    /// EAD label of the item
+    ///
+    /// # Caveats
+    ///
+    /// Currently, only values up to 23 are supported.
+    pub label: u16,
     pub is_critical: bool,
     // TODO[ead]: have adjustable (smaller) length for this buffer
     pub value: Option<EdhocMessageBuffer>,
@@ -717,7 +722,7 @@ mod edhoc_parser {
                     None
                 };
                 let ead_item = Some(EADItem {
-                    label,
+                    label: label.into(),
                     is_critical,
                     value: ead_value,
                 });

--- a/shared/src/python_bindings.rs
+++ b/shared/src/python_bindings.rs
@@ -49,7 +49,7 @@ impl From<EdhocBufferError> for PyErr {
 #[pymethods]
 impl EADItem {
     #[new]
-    fn new_py(label: u8, is_critical: bool, value: Vec<u8>) -> Self {
+    fn new_py(label: u16, is_critical: bool, value: Vec<u8>) -> Self {
         Self {
             label,
             is_critical,
@@ -63,7 +63,7 @@ impl EADItem {
             .map(|v| PyBytes::new_bound(py, v.as_slice()))
     }
 
-    fn label(&self) -> u8 {
+    fn label(&self) -> u16 {
         self.label
     }
 


### PR DESCRIPTION
The set of supported values is not changed, but the API is changed so that the implementation can be fixed without an extra breaking change.

---

Didn't run any special tests, let's see if CI is happy. (Should be a no-brainer though).