### PR TITLE
python: Enhance error handling

### DIFF
--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -181,7 +181,7 @@ impl PyEdhocInitiator {
     /// Key material can be extracted after this point, but some properties of the protocol only
     /// hold when non-EDHOC messages protected with the extracted key material are received from
     /// the peer.
-    pub fn completed_without_message_4<'a>(&mut self, py: Python<'a>) -> PyResult<()> {
+    pub fn completed_without_message_4<'a>(&mut self) -> PyResult<()> {
         let state = i_complete_without_message_4(&self.take_wait_m4()?)?;
         self.completed = Some(state);
         Ok(())

--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -14,12 +14,21 @@ mod responder;
 /// Error raised when operations on a Python object did not happen in the sequence in which they
 /// were intended.
 ///
-/// This currently has no more detailed response because for every situation this can occur in,
-/// there are different possible explainations that we can't get across easily in a single message.
-/// For example, if `responder.processing_m1` is absent, that can be either because no message 1
-/// was processed into it yet, or because message 2 was already generated.
+/// This carries data purely for the purpose of guiding the user towards an understanding of how
+/// things went wrong; for less powerful error reporting, this could be a ZSTs, and all its
+/// constructors, the `.summarize()` methods and the detailed `.take_…()`/`.as_ref_…()` methods
+/// could be plain `.take()`/`.as_ref()` on their fields.
 #[derive(Debug)]
-pub(crate) struct StateMismatch;
+pub(crate) struct StateMismatch<S> {
+    expected: S,
+    found: S,
+}
+
+impl<S> StateMismatch<S> {
+    pub(crate) fn new(expected: S, found: S) -> Self {
+        Self { expected, found }
+    }
+}
 
 trait ErrExt {
     type T;
@@ -40,15 +49,23 @@ impl<T, E: core::fmt::Display> ErrExt for Result<T, E> {
     }
 }
 
-impl std::error::Error for StateMismatch {}
-impl std::fmt::Display for StateMismatch {
+impl<S: Ord + core::fmt::Debug> std::error::Error for StateMismatch<S> {}
+impl<S: Ord + core::fmt::Debug> std::fmt::Display for StateMismatch<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Type state mismatch")
+        if self.expected < self.found {
+            write!(
+                f,
+                "State machine has progressed beyond expected {:?}, is already at {:?}",
+                self.expected, self.found
+            )
+        } else {
+            write!(f, "State machine is just at {:?}, but this operation requires it to have progressed to {:?}", self.found, self.expected)
+        }
     }
 }
-impl From<StateMismatch> for PyErr {
+impl<S: Ord + core::fmt::Debug> From<StateMismatch<S>> for PyErr {
     #[track_caller]
-    fn from(err: StateMismatch) -> PyErr {
+    fn from(err: StateMismatch<S>) -> PyErr {
         let location = std::panic::Location::caller();
         // It would be nice to inject something more idiomatic on the Python side, eg. setting a
         // cause with a Rust file and line number, but to create such an object we'd need the GIL,

--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -36,14 +36,14 @@ trait ErrExt {
 
 impl<T> ErrExt for Option<T> {
     type T = T;
-    fn with_cause(self, py: Python<'_>, cause: &str) -> Result<T, PyErr> {
+    fn with_cause(self, _py: Python<'_>, cause: &str) -> Result<T, PyErr> {
         self.ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{}", cause)))
     }
 }
 
 impl<T, E: core::fmt::Display> ErrExt for Result<T, E> {
     type T = T;
-    fn with_cause(self, py: Python<'_>, cause: &str) -> Result<T, PyErr> {
+    fn with_cause(self, _py: Python<'_>, cause: &str) -> Result<T, PyErr> {
         self.map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{} ({})", cause, e)))
     }
 }

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -183,7 +183,7 @@ impl PyEdhocResponder {
     ///
     /// Key material may be exported from this point, and is used to confirm key agreement to the
     /// initiator by using it to protect any next protocol.
-    pub fn completed_without_message_4<'a>(&mut self, py: Python<'a>) -> PyResult<()> {
+    pub fn completed_without_message_4<'a>(&mut self) -> PyResult<()> {
         let state = r_complete_without_message_4(&self.take_processed_m3()?)?;
         self.completed = Some(state);
         Ok(())

--- a/lakers-python/test/test_lakers.py
+++ b/lakers-python/test/test_lakers.py
@@ -105,6 +105,24 @@ def test_buffer_error():
         _ = initiator.parse_message_2(cbor2.dumps(bytes([1] * 10000)))
     assert str(err.value) == "Message 2 too long (MessageBufferError::SliceTooLong)"
 
+def test_state_missing_step():
+    initiator = EdhocInitiator()
+    with pytest.raises(RuntimeError) as err:
+        initiator.prepare_message_3(CredentialTransfer.ByReference, None)
+    assert str(err.value).startswith("State machine is just at Start, but this operation requires it to have progressed to ProcessedM2")
+
+def test_state_no_going_back():
+    initiator = EdhocInitiator()
+    message_1 = initiator.prepare_message_1(c_i=None, ead_1=None)
+
+    responder = EdhocResponder(R, CRED_R)
+    assert "Start" in repr(responder), f"Expected state to be reported in repr, found {responder!r}"
+    responder.process_message_1(message_1)
+    assert "ProcessingM1" in repr(responder), f"Expected state to be reported in repr, found {responder!r}"
+    with pytest.raises(RuntimeError) as err:
+        responder.process_message_1(message_1)
+    assert str(err.value).startswith("State machine has progressed beyond expected Start, is already at ProcessingM1"), str(err.value)
+
 def test_logging():
     LOGSTREAM.truncate(0)
     LOGSTREAM.seek(0)

--- a/lakers-python/test/test_lakers.py
+++ b/lakers-python/test/test_lakers.py
@@ -103,7 +103,7 @@ def test_buffer_error():
     initiator.prepare_message_1()
     with pytest.raises(ValueError) as err:
         _ = initiator.parse_message_2(cbor2.dumps(bytes([1] * 10000)))
-    assert str(err.value) == "MessageBufferError::SliceTooLong"
+    assert str(err.value) == "Message 2 too long (MessageBufferError::SliceTooLong)"
 
 def test_logging():
     LOGSTREAM.truncate(0)


### PR DESCRIPTION
I just spent way more time than I'm happy to admit debugging a case of feeding in the wrong kind of credential.

This PR goes through one commit of simplifying Python side error handling (no point doing the match to avoid the early returns when code is not hax'd), and then goes about adding some hints as to *what* failed to errors.