### PR TITLE
python: Add documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Maturin setup for readthedocs, copied from https://www.maturin.rs/sphinx.html and adjusted
+
+version: 2
+
+sphinx:
+  builder: html
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.12"
+    rust: "1.82"
+
+python:
+  install:
+    - method: pip
+      path: lakers-python
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: lakers-python/doc/conf.py

--- a/lakers-python/doc/conf.py
+++ b/lakers-python/doc/conf.py
@@ -1,0 +1,6 @@
+project = "lakers-python"
+copyright = "see project web page"
+
+extensions = [
+    "sphinx.ext.autodoc",
+]

--- a/lakers-python/doc/index.rst
+++ b/lakers-python/doc/index.rst
@@ -2,9 +2,15 @@
 lakers -- An implementation of EDHOC (RFC 9528) in Rust
 =======================================================
 
+This is the documentation of the Python bindings for Lakers,
+called lakers-python_.
+Documentation on the underlying Rust library is found `on docs.rs`_.
+
 See the project README_ file for installation, maintenance and license information.
 
 .. _README: https://github.com/openwsn-berkeley/lakers/blob/main/lakers-python/README.md
+.. _lakers-python: https://pypi.org/project/lakers-python/
+.. _`on docs.rs`: https://docs.rs/lakers/
 
 .. automodule:: lakers
    :members:

--- a/lakers-python/doc/index.rst
+++ b/lakers-python/doc/index.rst
@@ -1,0 +1,40 @@
+=======================================================
+lakers -- An implementation of EDHOC (RFC 9528) in Rust
+=======================================================
+
+See the project README_ file for installation, maintenance and license information.
+
+.. _README: https://github.com/openwsn-berkeley/lakers/blob/main/lakers-python/README.md
+
+.. automodule:: lakers
+   :members:
+   :undoc-members:
+   :exclude-members: EdhocInitiator, EdhocResponder
+
+   These are the two main entry points:
+
+   .. autoclass:: EdhocInitiator
+     :exclude-members: prepare_message_1, parse_message_2, verify_message_2, prepare_message_3, completed_without_message_4, process_message_4
+     :members:
+     :undoc-members:
+
+     .. automethod:: prepare_message_1
+     .. automethod:: parse_message_2
+     .. automethod:: verify_message_2
+     .. automethod:: prepare_message_3
+     .. automethod:: completed_without_message_4
+     .. automethod:: process_message_4
+
+   .. autoclass:: EdhocResponder
+     :members:
+     :exclude-members: process_message_1, prepare_message_2, parse_message_3, verify_message_3, completed_without_message_4, prepare_message_4
+     :undoc-members:
+
+     .. automethod:: process_message_1
+     .. automethod:: prepare_message_2
+     .. automethod:: parse_message_3
+     .. automethod:: verify_message_3
+     .. automethod:: completed_without_message_4
+     .. automethod:: prepare_message_4
+
+   Several tool classes augment the operation of those classes:

--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -5,6 +5,7 @@ use pyo3::{prelude::*, types::PyBytes};
 
 use super::StateMismatch;
 
+/// An implementation of the EDHOC protocol for the initiator side.
 #[pyclass(name = "EdhocInitiator")]
 pub struct PyEdhocInitiator {
     cred_i: Option<Credential>,
@@ -45,6 +46,10 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Generates message 1.
+    ///
+    /// At this point, a ``C_I`` (connection identifier) may be provided, as well as additonal EAD
+    /// data.
     #[pyo3(signature = (c_i=None, ead_1=None))]
     fn prepare_message_1<'a>(
         &mut self,
@@ -68,6 +73,12 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Process message 2.
+    ///
+    /// This produces both the ``C_R`` and the ``ID_CRED_R``, and maybe additional EAD data sent by
+    /// the responder, but does not verify them yet: They are only verified when the application
+    /// provides the expanded credential ``CRED_R`` (typically based on the information in
+    /// ``ID_CRED_R``) in :meth:`.verify_message_2()`.
     pub fn parse_message_2<'a>(
         &mut self,
         py: Python<'a>,
@@ -92,6 +103,11 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Verifies the previously inserted message 2.
+    ///
+    /// At this point, the initiator's private key ``I`` as well as the initiator's identity ``CRED_I``
+    /// needs to be provided, as well as the peer's credential ``CRED_R`` (as looked up by its
+    /// ``ID_CRED_R`` from the preceeding :meth:`parse_message_2()` output).
     pub fn verify_message_2(
         &mut self,
         i: Vec<u8>,
@@ -118,6 +134,10 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Generates a message 3.
+    ///
+    /// Input influences whether the credential previously provided in :meth:`verify_message_2()` is
+    /// sent by value or reference, and whether any additional EAD data is to be sent.
     #[pyo3(signature = (cred_transfer, ead_3=None))]
     pub fn prepare_message_3<'a>(
         &mut self,
@@ -143,6 +163,11 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Declares the protocol to have completed without the need of a message 4.
+    ///
+    /// Key material can be extracted after this point, but some properties of the protocol only
+    /// hold when non-EDHOC messages protected with the extracted key material are received from
+    /// the peer.
     pub fn completed_without_message_4<'a>(&mut self, py: Python<'a>) -> PyResult<()> {
         match i_complete_without_message_4(&self.wait_m4.take().ok_or(StateMismatch)?) {
             Ok(state) => {
@@ -153,6 +178,9 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Processes and verifies message 4.
+    ///
+    /// This produces EAD data if the peer sent any.
     pub fn process_message_4<'a>(
         &mut self,
         py: Python<'a>,
@@ -173,6 +201,7 @@ impl PyEdhocInitiator {
         }
     }
 
+    /// Exports key material.
     pub fn edhoc_exporter<'a>(
         &mut self,
         py: Python<'a>,
@@ -194,6 +223,7 @@ impl PyEdhocInitiator {
         Ok(PyBytes::new_bound(py, &res[..length]))
     }
 
+    /// Performs the key update procedure, enabling the production of new key material.
     pub fn edhoc_key_update<'a>(
         &mut self,
         py: Python<'a>,
@@ -229,6 +259,7 @@ impl PyEdhocInitiator {
         Ok(PyBytes::new_bound(py, &secret[..]))
     }
 
+    /// The cipher suite that is agreed on by the exchange.
     pub fn selected_cipher_suite(&self) -> PyResult<u8> {
         Ok(self.start.suites_i[self.start.suites_i.len() - 1])
     }

--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -96,14 +96,14 @@ impl AutoCredential {
     }
 }
 
-/// Lakers implementation of EDHOC.
+/// The :class:`EdhocInitiator` and :class:`EdhocResponder` are entry points to this module. Both
+/// provided classes that represent one side of the EDHOC exchange, and are updated with and
+/// produce messages and information through a series of method calls on the object.
 ///
-/// The `EdhocInitiator` and `EdhocResponder` are entry points to this module.
-///
-/// Operations in this module produce logging entries on the `lakers.initiator` and
-/// `lakers.responder` logger names. Due to implementation details of `pyo3_log`, Python's log
+/// Operations in this module produce logging entries on the ``lakers.initiator`` and
+/// ``lakers.responder`` logger names. Due to implementation details of ``pyo3_log``, Python's log
 /// levels are cached in the Rust implementation. It is recommended that the full logging
-/// is configured before creating Lakers objects. A setup with `logging.basicConfig(loglevel=5)`
+/// is configured before creating Lakers objects. A setup with ``logging.basicConfig(loglevel=5)``
 /// will also show Lakers' trace level log messages, which have no equivalent Python level.
 #[pymodule]
 // this name must match `lib.name` in `Cargo.toml`

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -156,7 +156,7 @@ impl IdCred {
     }
 }
 
-/// A credential for use in EDHOC
+/// A credential for use in EDHOC.
 ///
 /// For now supports CCS credentials only.
 /// Experimental support for CCS_PSK credentials is also available.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -542,11 +542,21 @@ pub struct Completed {
     pub prk_exporter: BytesHashLen,
 }
 
+/// An enum describing options how to send credentials.
 #[cfg_attr(feature = "python-bindings", pyclass(eq, eq_int))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub enum CredentialTransfer {
+    /// This sends a short reference (key ID) of the credential.
+    ///
+    /// In order to complete the protocol, the peer needs to either know the full credential, or
+    /// load it from an external source, or extract it from (possibly protected) EAD data such as
+    /// a CWT.
     ByReference,
+    /// This sends a credential by value.
+    ///
+    /// The peer can complete the protocol without additional information, although in most cases
+    /// the peer will still need to inspect the value.
     ByValue,
 }
 


### PR DESCRIPTION
This adds all the steps that once the package is installed, `sphinx-build doc html` in the lakers-python directory will produce reasonably usable HTML docs. Those could be autogenerated on readthedocs (I can set that up) or on hosted pages if you want to play with GitHub (I prefer the former).

Missing steps:

* [ ] Find which workaround for https://github.com/PyO3/pyo3/issues/4326 we want to use. In particular, this affects `Credential`, but I'm a bit reluctant to start fixing it there because the documentation is outdated from the back-and-forth on non-CCS credentials.
* [x] Get an account at readthedocs and publish there
* [ ] Do we wait for https://github.com/openwsn-berkeley/lakers/issues/282, or do nothing, or manually add some more hints so that users get any idea on which types to throw in where?

Closes: https://github.com/openwsn-berkeley/lakers/issues/345