### PR TITLE
Eaditem option to array

### DIFF
--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -37,7 +37,7 @@ impl ZeroTouchServer {
         let (_method, _suites_i, g_x, _c_i, ead_1) = parse_message_1(&message_1)?;
         let prk = compute_prk(crypto, &self.w, &g_x);
 
-        let (_loc_w, enc_id) = parse_ead_1_value(&ead_1.unwrap().value.unwrap())?;
+        let (_loc_w, enc_id) = parse_ead_1_value(&ead_1[0].value.unwrap())?;
         let id_u_encoded = decrypt_enc_id(crypto, &prk, &enc_id, EDHOC_SUPPORTED_SUITES[0])?;
         let id_u = decode_id_u(id_u_encoded)?;
 
@@ -80,7 +80,7 @@ impl ZeroTouchServerUserAcl {
         let (_method, _suites_i, g_x, _c_i, ead_1) = parse_message_1(&message_1)?;
         let prk = compute_prk(crypto, &self.w, &g_x);
 
-        let (_loc_w, enc_id) = parse_ead_1_value(&ead_1.unwrap().value.unwrap())?;
+        let (_loc_w, enc_id) = parse_ead_1_value(&ead_1[0].value.unwrap())?;
         let id_u_encoded = decrypt_enc_id(crypto, &prk, &enc_id, EDHOC_SUPPORTED_SUITES[0])?;
 
         decode_id_u(id_u_encoded)

--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -42,7 +42,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     // Send Message 1 over CoAP and convert the response to byte
     let mut msg_1_buf = Vec::from([0xf5u8]); // EDHOC message_1 when transported over CoAP is prepended with CBOR true
     let c_i = generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto());
-    let (initiator, message_1) = initiator.prepare_message_1(Some(c_i), &None)?;
+    let (initiator, message_1) = initiator.prepare_message_1(Some(c_i), &EADItem::new_array())?;
     msg_1_buf.extend_from_slice(message_1.as_slice());
     println!("message_1 len = {}", msg_1_buf.len());
 
@@ -61,7 +61,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
 
     let mut msg_3 = Vec::from(c_r.as_cbor());
     let (initiator, message_3, prk_out) =
-        initiator.prepare_message_3(CredentialTransfer::ByReference, &None)?;
+        initiator.prepare_message_3(CredentialTransfer::ByReference, &EADItem::new_array())?;
     msg_3.extend_from_slice(message_3.as_slice());
     println!("message_3 len = {}", msg_3.len());
 

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -60,7 +60,10 @@ fn main() {
                 if let Ok((responder, _c_i, ead_1)) = result {
                     let c_r =
                         generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto());
-                    let ead_2 = if let Some(ead_1) = ead_1 {
+
+                    let mut ead_2 = EADItem::new_array();
+                    if ead_1[0].value.is_some() {
+                        let ead_1 = &ead_1[0];
                         let authenticator = ZeroTouchAuthenticator::default();
                         let (authenticator, _loc_w, voucher_request) =
                             authenticator.process_ead_1(&ead_1, &message_1).unwrap();
@@ -75,9 +78,8 @@ fn main() {
 
                         let res = authenticator.prepare_ead_2(&voucher_response);
                         assert!(res.is_ok());
-                        authenticator.prepare_ead_2(&voucher_response).ok()
-                    } else {
-                        None
+
+                        ead_2[0] = res.unwrap();
                     };
                     let (responder, message_2) = responder
                         .prepare_message_2(CredentialTransfer::ByReference, Some(c_r), &ead_2)
@@ -113,7 +115,8 @@ fn main() {
                     println!("EDHOC error at verify_message_3: {:?}", valid_cred_i);
                     continue;
                 };
-                let (mut responder, message_4) = responder.prepare_message_4(&None).unwrap();
+                let (mut responder, message_4) =
+                    responder.prepare_message_4(&EADItem::new_array()).unwrap();
                 // send empty ack back
                 response.message.payload = Vec::from(message_4.as_slice());
 

--- a/examples/lakers-no_std/src/main.rs
+++ b/examples/lakers-no_std/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> ! {
 
         let _c_i =
             generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto()).as_slice();
-        let message_1 = initiator.prepare_message_1(None, &None);
+        let message_1 = initiator.prepare_message_1(None, &EADItem::new_array());
         assert!(message_1.is_ok());
     }
 
@@ -113,11 +113,13 @@ fn main() -> ! {
             cred_r.clone(),
         );
 
-        let (initiator, message_1) = initiator.prepare_message_1(None, &None).unwrap();
+        let (initiator, message_1) = initiator
+            .prepare_message_1(None, &EADItem::new_array())
+            .unwrap();
 
         let (responder, _c_i, _ead_1) = responder.process_message_1(&message_1).unwrap();
         let (responder, message_2) = responder
-            .prepare_message_2(CredentialTransfer::ByReference, None, &None)
+            .prepare_message_2(CredentialTransfer::ByReference, None, &EADItem::new_array())
             .unwrap();
 
         let (mut initiator, _c_r, id_cred_r, _ead_2) =
@@ -132,7 +134,7 @@ fn main() -> ! {
         let initiator = initiator.verify_message_2(valid_cred_r).unwrap();
 
         let (initiator, message_3, i_prk_out) = initiator
-            .prepare_message_3(CredentialTransfer::ByReference, &None)
+            .prepare_message_3(CredentialTransfer::ByReference, &EADItem::new_array())
             .unwrap();
 
         let (responder, id_cred_i, _ead_3) = responder.parse_message_3(&message_3).unwrap();

--- a/examples/lakers-nrf52840/src/bin/initiator.rs
+++ b/examples/lakers-nrf52840/src/bin/initiator.rs
@@ -78,7 +78,9 @@ async fn main(spawner: Spawner) {
 
     // Send Message 1 over raw BLE and convert the response to byte
     let c_i = generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto());
-    let (initiator, message_1) = initiator.prepare_message_1(Some(c_i), &None).unwrap();
+    let (initiator, message_1) = initiator
+        .prepare_message_1(Some(c_i), &EADItem::new_array())
+        .unwrap();
     let pckt_1 = common::Packet::new_from_slice(message_1.as_slice(), Some(0xf5))
         .expect("Buffer not long enough");
     let rcvd = common::transmit_and_wait_response(&mut radio, pckt_1, Some(0xf5)).await;

--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -76,12 +76,12 @@ impl PyEdhocInitiator {
     ///
     /// At this point, a ``C_I`` (connection identifier) may be provided, as well as additonal EAD
     /// data.
-    #[pyo3(signature = (c_i=None, ead_1=None))]
+    #[pyo3(signature = (c_i=None, ead_1=EADItem::new_array()))]
     fn prepare_message_1<'a>(
         &mut self,
         py: Python<'a>,
         c_i: Option<Vec<u8>>,
-        ead_1: Option<EADItem>,
+        ead_1: [EADItem; MAX_EAD_ITEMS],
     ) -> PyResult<Bound<'a, PyBytes>> {
         let c_i = match c_i {
             Some(c_i) => ConnId::from_slice(c_i.as_slice())
@@ -105,7 +105,11 @@ impl PyEdhocInitiator {
         &mut self,
         py: Python<'a>,
         message_2: Vec<u8>,
-    ) -> PyResult<(Bound<'a, PyBytes>, Bound<'a, PyBytes>, Option<EADItem>)> {
+    ) -> PyResult<(
+        Bound<'a, PyBytes>,
+        Bound<'a, PyBytes>,
+        [EADItem; MAX_EAD_ITEMS],
+    )> {
         let message_2 = EdhocMessageBuffer::new_from_slice(message_2.as_slice())
             .with_cause(py, "Message 2 too long")?;
 
@@ -155,12 +159,12 @@ impl PyEdhocInitiator {
     ///
     /// Input influences whether the credential previously provided in :meth:`verify_message_2()` is
     /// sent by value or reference, and whether any additional EAD data is to be sent.
-    #[pyo3(signature = (cred_transfer, ead_3=None))]
+    #[pyo3(signature = (cred_transfer, ead_3=EADItem::new_array()))]
     pub fn prepare_message_3<'a>(
         &mut self,
         py: Python<'a>,
         cred_transfer: CredentialTransfer,
-        ead_3: Option<EADItem>,
+        ead_3: [EADItem; MAX_EAD_ITEMS],
     ) -> PyResult<(Bound<'a, PyBytes>, Bound<'a, PyBytes>)> {
         let (state, message_3, prk_out) = i_prepare_message_3(
             &mut self.take_processed_m2()?,
@@ -194,7 +198,7 @@ impl PyEdhocInitiator {
         &mut self,
         py: Python<'a>,
         message_4: Vec<u8>,
-    ) -> PyResult<Option<EADItem>> {
+    ) -> PyResult<[EADItem; MAX_EAD_ITEMS]> {
         let message_4 = EdhocMessageBuffer::new_from_slice(message_4.as_slice())
             .with_cause(py, "Message 4 too long")?;
         let (state, ead_4) =

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -78,7 +78,7 @@ impl PyEdhocResponder {
         &mut self,
         py: Python<'a>,
         message_1: Vec<u8>,
-    ) -> PyResult<(Bound<'a, PyBytes>, Option<EADItem>)> {
+    ) -> PyResult<(Bound<'a, PyBytes>, [EADItem; MAX_EAD_ITEMS])> {
         let message_1 = EdhocMessageBuffer::new_from_slice(message_1.as_slice())
             .with_cause(py, "Message 1 too long")?;
         let (state, c_i, ead_1) =
@@ -93,13 +93,13 @@ impl PyEdhocResponder {
     ///
     /// Input influences whether the credential is sent by value or reference, which credential is
     /// sent, and whether any optional EAD data is to be sent.
-    #[pyo3(signature = (cred_transfer, c_r=None, ead_2=None))]
+    #[pyo3(signature = (cred_transfer, c_r=None, ead_2=EADItem::new_array()))]
     fn prepare_message_2<'a>(
         &mut self,
         py: Python<'a>,
         cred_transfer: CredentialTransfer,
         c_r: Option<Vec<u8>>,
-        ead_2: Option<EADItem>,
+        ead_2: [EADItem; MAX_EAD_ITEMS],
     ) -> PyResult<Bound<'a, PyBytes>> {
         let c_r = match c_r {
             Some(c_r) => ConnId::from_slice(c_r.as_slice())
@@ -132,7 +132,7 @@ impl PyEdhocResponder {
         &mut self,
         py: Python<'a>,
         message_3: Vec<u8>,
-    ) -> PyResult<(Bound<'a, PyBytes>, Option<EADItem>)> {
+    ) -> PyResult<(Bound<'a, PyBytes>, [EADItem; MAX_EAD_ITEMS])> {
         let message_3 = EdhocMessageBuffer::new_from_slice(message_3.as_slice())
             .with_cause(py, "Message 3 too long")?;
         let (state, id_cred_i, ead_3) =
@@ -167,11 +167,11 @@ impl PyEdhocResponder {
     /// This may contain additional EAD data.
     ///
     /// After generating this message, the protocol has completed.
-    #[pyo3(signature = (ead_4=None))]
+    #[pyo3(signature = (ead_4=EADItem::new_array()))]
     fn prepare_message_4<'a>(
         &mut self,
         py: Python<'a>,
-        ead_4: Option<EADItem>,
+        ead_4: [EADItem; MAX_EAD_ITEMS],
     ) -> PyResult<Bound<'a, PyBytes>> {
         let (state, message_4) =
             r_prepare_message_4(&self.take_processed_m3()?, &mut default_crypto(), &ead_4)?;

--- a/lakers-python/test/test_ead_authz.py
+++ b/lakers-python/test/test_ead_authz.py
@@ -60,32 +60,37 @@ def test_handshake_with_authz():
     )
 
     # initiator
-    ead_1 = device.prepare_ead_1(
+    ead_1 = lakers.EADItem.new_array_py()
+    ead_1[0] = device.prepare_ead_1(
         initiator.compute_ephemeral_secret(device.get_g_w()),
         initiator.selected_cipher_suite(),
     )
+
     message_1 = initiator.prepare_message_1(c_i=None, ead_1=ead_1)
     device.set_h_message_1(initiator.get_h_message_1())
 
     # responder
     _c_i, ead_1 = responder.process_message_1(message_1)
-    loc_w, voucher_request = authenticator.process_ead_1(ead_1, message_1)
+    loc_w, voucher_request = authenticator.process_ead_1(ead_1[0], message_1)
     voucher_response = enrollment_server.handle_voucher_request(voucher_request)
-    ead_2 = authenticator.prepare_ead_2(voucher_response)
+    ead_2 = lakers.EADItem.new_array_py()
+    ead_2[0] = authenticator.prepare_ead_2(voucher_response)
     message_2 = responder.prepare_message_2(lakers.CredentialTransfer.ByReference, None, ead_2)
     assert type(message_2) == bytes
 
     # initiator
     c_r, id_cred_r, ead_2 = initiator.parse_message_2(message_2)
     valid_cred_r = lakers.credential_check_or_fetch(id_cred_r, CRED_V)
-    assert device.process_ead_2(ead_2, CRED_V) # voucher is valid!
+    assert device.process_ead_2(ead_2[0], CRED_V) # voucher is valid!
     initiator.verify_message_2(I, CRED_I, valid_cred_r)
-    message_3, i_prk_out = initiator.prepare_message_3(lakers.CredentialTransfer.ByReference, None)
+    message_3, i_prk_out = initiator.prepare_message_3(lakers.CredentialTransfer.ByReference, lakers.EADItem.new_array_py())
     assert type(message_3) == bytes
 
     # responder
     id_cred_i, ead_3 = responder.parse_message_3(message_3)
-    assert ead_3 == None
+    for ead in ead_3:
+        assert ead.is_critical() == False
+        assert ead.value() == None
     valid_cred_i = lakers.credential_check_or_fetch(id_cred_i, CRED_I)
     r_prk_out = responder.verify_message_3(valid_cred_i)
 

--- a/lakers-python/test/test_lakers.py
+++ b/lakers-python/test/test_lakers.py
@@ -3,7 +3,7 @@ import logging
 import lakers
 import cbor2
 import pytest
-from lakers import CredentialTransfer, EdhocInitiator, EdhocResponder
+from lakers import CredentialTransfer, EdhocInitiator, EdhocResponder, EADItem
 
 # This needs to be early, thus top-level: Once Lakers objects are created, the
 # log level is fixed.
@@ -24,7 +24,7 @@ def test_gen_keys():
 
 def test_initiator():
     initiator = EdhocInitiator()
-    message_1 = initiator.prepare_message_1(c_i=None, ead_1=None)
+    message_1 = initiator.prepare_message_1(c_i=None, ead_1=EADItem.new_array_py())
     assert type(message_1) == bytes
 
 def test_responder():
@@ -52,28 +52,28 @@ def _test_handshake(cred_r_transfer, cred_i_transfer):
     responder = EdhocResponder(R, CRED_R)
 
     # initiator
-    message_1 = initiator.prepare_message_1(c_i=None, ead_1=None)
+    message_1 = initiator.prepare_message_1(c_i=None, ead_1=EADItem.new_array_py())
 
     # responder
     _c_i, ead_1 = responder.process_message_1(message_1)
-    assert ead_1 == None
+    assert ead_1[0].value() == None
     message_2 = responder.prepare_message_2(cred_r_transfer, None, ead_1)
     assert type(message_2) == bytes
 
     # initiator
     c_r, id_cred_r, ead_2 = initiator.parse_message_2(message_2)
-    assert ead_2 == None
+    assert ead_2[0].value() == None
     valid_cred_r = lakers.credential_check_or_fetch(id_cred_r, CRED_R)
     initiator.verify_message_2(I, CRED_I, valid_cred_r)
-    message_3, i_prk_out = initiator.prepare_message_3(cred_i_transfer, None)
+    message_3, i_prk_out = initiator.prepare_message_3(cred_i_transfer, EADItem.new_array_py())
     assert type(message_3) == bytes
 
     # responder
     id_cred_i, ead_3 = responder.parse_message_3(message_3)
-    assert ead_3 == None
+    assert ead_3[0].value() == None
     valid_cred_i = lakers.credential_check_or_fetch(id_cred_i, CRED_I)
     r_prk_out = responder.verify_message_3(valid_cred_i)
-    message_4 = responder.prepare_message_4(None)
+    message_4 = responder.prepare_message_4(EADItem.new_array_py())
 
     assert i_prk_out == r_prk_out
 
@@ -108,12 +108,12 @@ def test_buffer_error():
 def test_state_missing_step():
     initiator = EdhocInitiator()
     with pytest.raises(RuntimeError) as err:
-        initiator.prepare_message_3(CredentialTransfer.ByReference, None)
+        initiator.prepare_message_3(CredentialTransfer.ByReference, EADItem.new_array_py())
     assert str(err.value).startswith("State machine is just at Start, but this operation requires it to have progressed to ProcessedM2")
 
 def test_state_no_going_back():
     initiator = EdhocInitiator()
-    message_1 = initiator.prepare_message_1(c_i=None, ead_1=None)
+    message_1 = initiator.prepare_message_1(c_i=None, ead_1=EADItem.new_array_py())
 
     responder = EdhocResponder(R, CRED_R)
     assert "Start" in repr(responder), f"Expected state to be reported in repr, found {responder!r}"

--- a/lib/README.md
+++ b/lib/README.md
@@ -40,13 +40,13 @@ Here's a quick look at the API for the Initiator role (for the Responder role, a
 // perform the handshake
 let initiator = EdhocInitiator::new(default_crypto());
 
-let (initiator, message_1) = initiator.prepare_message_1(None, &None)?; // c_i and ead_1 are set to None
+let (initiator, message_1) = initiator.prepare_message_1(None, &EADItem::new_array())?; // c_i and ead_1 are set to None
 
 let (initiator, _c_r, id_cred_r, _ead_2) = initiator.parse_message_2(&message_2)?;
 let valid_cred_r = credential_check_or_fetch(Some(CRED_R), id_cred_r)?; // CRED_R contains Responder's public key
 let initiator = initiator.verify_message_2(I, cred_i, valid_cred_r)?; // I is Initiator's private key
 
-let (mut initiator, message_3, i_prk_out) = initiator.prepare_message_3(CredentialTransfer::ByReference, &None)?; // no ead_3
+let (mut initiator, message_3, i_prk_out) = initiator.prepare_message_3(CredentialTransfer::ByReference, &EADItem::new_array())?; // no ead_3
 
 // derive a secret to use with OSCORE
 let oscore_secret = initiator.edhoc_exporter(0u8, &[], 16); // label is 0

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -53,7 +53,7 @@ pub fn r_process_message_1(
     state: &ResponderStart,
     crypto: &mut impl CryptoTrait,
     message_1: &BufferMessage1,
-) -> Result<(ProcessingM1, ConnId, Option<EADItem>), EDHOCError> {
+) -> Result<(ProcessingM1, ConnId, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
     // Step 1: decode message_1
     // g_x will be saved to the state
     if let Ok((method, suites_i, g_x, c_i, ead_1)) = parse_message_1(message_1) {
@@ -95,7 +95,7 @@ pub fn r_prepare_message_2(
     r: &BytesP256ElemLen, // R's static private DH key
     c_r: ConnId,
     cred_transfer: CredentialTransfer,
-    ead_2: &Option<EADItem>,
+    ead_2: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<(WaitM3, BufferMessage2), EDHOCError> {
     // compute TH_2
     let th_2 = compute_th_2(crypto, &state.g_y, &state.h_message_1);
@@ -151,7 +151,7 @@ pub fn r_parse_message_3(
     state: &mut WaitM3,
     crypto: &mut impl CryptoTrait,
     message_3: &BufferMessage3,
-) -> Result<(ProcessingM3, IdCred, Option<EADItem>), EDHOCError> {
+) -> Result<(ProcessingM3, IdCred, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
     let plaintext_3 = decrypt_message_3(crypto, &state.prk_3e2m, &state.th_3, message_3);
 
     if let Ok(plaintext_3) = plaintext_3 {
@@ -259,7 +259,7 @@ pub fn r_verify_message_3(
 pub fn r_prepare_message_4(
     state: &ProcessedM3,
     crypto: &mut impl CryptoTrait,
-    ead_4: &Option<EADItem>, // FIXME: make it a list of EADItem
+    ead_4: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<(Completed, BufferMessage4), EDHOCError> {
     // compute ciphertext_4
     let plaintext_4 = encode_plaintext_4(&ead_4)?;
@@ -285,10 +285,10 @@ pub fn i_prepare_message_1(
     state: &InitiatorStart,
     crypto: &mut impl CryptoTrait,
     c_i: ConnId,
-    ead_1: &Option<EADItem>, // FIXME: make it a list of EADItem
+    ead_1: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<(WaitM2, BufferMessage1), EDHOCError> {
     // Encode message_1 as a sequence of CBOR encoded data items as specified in Section 5.2.1
-    let message_1 = encode_message_1(state.method, &state.suites_i, &state.g_x, c_i, ead_1)?;
+    let message_1 = encode_message_1(state.method, &state.suites_i, &state.g_x, c_i, &ead_1)?;
 
     let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
     message_1_buf[..message_1.len].copy_from_slice(message_1.as_slice());
@@ -310,7 +310,7 @@ pub fn i_parse_message_2<'a>(
     state: &WaitM2,
     crypto: &mut impl CryptoTrait,
     message_2: &BufferMessage2,
-) -> Result<(ProcessingM2, ConnId, IdCred, Option<EADItem>), EDHOCError> {
+) -> Result<(ProcessingM2, ConnId, IdCred, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
     let res = parse_message_2(message_2);
     if let Ok((g_y, ciphertext_2)) = res {
         let th_2 = compute_th_2(crypto, &g_y, &state.h_message_1);
@@ -403,7 +403,7 @@ pub fn i_prepare_message_3(
     crypto: &mut impl CryptoTrait,
     cred_i: Credential,
     cred_transfer: CredentialTransfer,
-    ead_3: &Option<EADItem>, // FIXME: make it a list of EADItem
+    ead_3: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<(WaitM4, BufferMessage3, BytesHashLen), EDHOCError> {
     let id_cred_i = match cred_transfer {
         CredentialTransfer::ByValue => cred_i.by_value()?,
@@ -469,7 +469,7 @@ pub fn i_process_message_4(
     state: &mut WaitM4,
     crypto: &mut impl CryptoTrait,
     message_4: &BufferMessage4,
-) -> Result<(Completed, Option<EADItem>), EDHOCError> {
+) -> Result<(Completed, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
     let plaintext_4 = decrypt_message_4(crypto, &state.prk_4e3m, &state.th_4, &message_4)?;
     let decoded_p4_res = decode_plaintext_4(&plaintext_4);
 
@@ -514,14 +514,12 @@ fn encode_ead_item(ead_1: &EADItem) -> Result<EdhocMessageBuffer, EDHOCError> {
 
         // encode value
         if let Some(ead_1_value) = &ead_1.value {
-            if output.extend_from_slice(ead_1_value.as_slice()).is_ok() {
-                Ok(output)
-            } else {
-                Err(EDHOCError::EadTooLongError)
-            }
-        } else {
-            Ok(output)
+            output
+                .extend_from_slice(ead_1_value.as_slice())
+                .map_err(|_| EDHOCError::EadTooLongError)?;
         }
+
+        Ok(output)
     } else {
         Err(EDHOCError::EadLabelTooLongError)
     }
@@ -532,7 +530,7 @@ fn encode_message_1(
     suites: &EdhocBuffer<MAX_SUITES_LEN>,
     g_x: &BytesP256ElemLen,
     c_i: ConnId,
-    ead_1: &Option<EADItem>,
+    ead_1: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<BufferMessage1, EDHOCError> {
     let mut output = BufferMessage1::new();
     let mut raw_suites_len: usize = 0;
@@ -573,17 +571,16 @@ fn encode_message_1(
     output.len = 3 + raw_suites_len + P256_ELEM_LEN + c_i.len();
     output.content[3 + raw_suites_len + P256_ELEM_LEN..][..c_i.len()].copy_from_slice(c_i);
 
-    if let Some(ead_1) = ead_1 {
-        match encode_ead_item(ead_1) {
-            Ok(ead_1) => output
-                .extend_from_slice(ead_1.as_slice())
-                .and(Ok(output))
-                .or(Err(EDHOCError::EadTooLongError)),
-            Err(e) => Err(e),
+    for ead in ead_1 {
+        if ead.value.is_some() {
+            let encoded = encode_ead_item(&ead)?;
+            output
+                .extend_from_slice(encoded.as_slice())
+                .map_err(|_| EDHOCError::EadTooLongError)?;
         }
-    } else {
-        Ok(output)
     }
+
+    Ok(output)
 }
 
 fn encode_message_2(g_y: &BytesP256ElemLen, ciphertext_2: &BufferCiphertext2) -> BufferMessage2 {
@@ -673,7 +670,7 @@ fn edhoc_kdf(
 fn encode_plaintext_3(
     id_cred_i: &[u8],
     mac_3: &BytesMac3,
-    ead_3: &Option<EADItem>,
+    ead_3: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<BufferPlaintext3, EDHOCError> {
     let mut plaintext_3: BufferPlaintext3 = BufferPlaintext3::new();
 
@@ -687,33 +684,31 @@ fn encode_plaintext_3(
     plaintext_3.content[offset_cred + 1..][..mac_3.len()].copy_from_slice(&mac_3[..]);
     plaintext_3.len = offset_cred + 1 + mac_3.len();
 
-    if let Some(ead_3) = ead_3 {
-        match encode_ead_item(ead_3) {
-            Ok(ead_3) => plaintext_3
-                .extend_from_slice(ead_3.as_slice())
-                .and(Ok(plaintext_3))
-                .or(Err(EDHOCError::EadTooLongError)),
-            Err(e) => Err(e),
+    for ead in ead_3 {
+        if ead.value.is_some() {
+            let encoded = encode_ead_item(&ead)?;
+            plaintext_3
+                .extend_from_slice(encoded.as_slice())
+                .map_err(|_| EDHOCError::EadTooLongError)?;
         }
-    } else {
-        Ok(plaintext_3)
     }
+
+    Ok(plaintext_3)
 }
 
-fn encode_plaintext_4(ead_4: &Option<EADItem>) -> Result<BufferPlaintext4, EDHOCError> {
+fn encode_plaintext_4(ead_4: &[EADItem; MAX_EAD_ITEMS]) -> Result<BufferPlaintext4, EDHOCError> {
     let mut plaintext_4: BufferPlaintext4 = BufferPlaintext4::new();
 
-    if let Some(ead_4) = ead_4 {
-        match encode_ead_item(ead_4) {
-            Ok(ead_4) => plaintext_4
-                .extend_from_slice(ead_4.as_slice())
-                .and(Ok(plaintext_4))
-                .or(Err(EDHOCError::EadTooLongError)),
-            Err(e) => Err(e),
+    for ead in ead_4 {
+        if ead.value.is_some() {
+            let encoded = encode_ead_item(&ead)?;
+            plaintext_4
+                .extend_from_slice(encoded.as_slice())
+                .map_err(|_| EDHOCError::EadTooLongError)?;
         }
-    } else {
-        Ok(plaintext_4)
     }
+
+    Ok(plaintext_4)
 }
 
 fn encode_enc_structure(th_3: &BytesHashLen) -> BytesEncStructureLen {
@@ -938,7 +933,7 @@ fn encode_kdf_context(
     id_cred: &[u8],
     th: &BytesHashLen,
     cred: &[u8],
-    ead: &Option<EADItem>,
+    ead: &[EADItem; MAX_EAD_ITEMS],
 ) -> (BytesMaxContextBuffer, usize) {
     // encode context in line
     // assumes ID_CRED_R and CRED_R are already CBOR-encoded (and also EAD)
@@ -962,13 +957,13 @@ fn encode_kdf_context(
 
     output_len = output_len + id_cred.len() + 2 + th.len() + cred.len();
 
-    output_len += if let Some(ead) = ead {
-        let encoded_ead = encode_ead_item(ead).unwrap(); // NOTE: this re-encoding could be avoided by passing just a reference to ead in the decrypted plaintext
-        output[output_len..output_len + encoded_ead.len].copy_from_slice(encoded_ead.as_slice());
-        encoded_ead.len
-    } else {
-        0
-    };
+    for e in ead {
+        if e.value.is_some() {
+            let encoded = encode_ead_item(&e).unwrap();
+            output[output_len..output_len + encoded.len].copy_from_slice(encoded.as_slice());
+            output_len += encoded.len
+        }
+    }
 
     (output, output_len)
 }
@@ -979,7 +974,7 @@ fn compute_mac_3(
     th_3: &BytesHashLen,
     id_cred_i: &[u8],
     cred_i: &[u8],
-    ead_3: &Option<EADItem>,
+    ead_3: &[EADItem; MAX_EAD_ITEMS],
 ) -> BytesMac3 {
     // MAC_3 = EDHOC-KDF( PRK_4e3m, 6, context_3, mac_length_3 )
     let (context, context_len) = encode_kdf_context(None, id_cred_i, th_3, cred_i, ead_3);
@@ -1006,7 +1001,7 @@ fn compute_mac_2(
     id_cred_r: &[u8],
     cred_r: &[u8],
     th_2: &BytesHashLen,
-    ead_2: &Option<EADItem>,
+    ead_2: &[EADItem; MAX_EAD_ITEMS],
 ) -> BytesMac2 {
     // compute MAC_2
     let (context, context_len) = encode_kdf_context(Some(c_r), id_cred_r, th_2, cred_r, ead_2);
@@ -1024,7 +1019,7 @@ fn encode_plaintext_2(
     c_r: ConnId,
     id_cred_r: &[u8],
     mac_2: &BytesMac2,
-    ead_2: &Option<EADItem>,
+    ead_2: &[EADItem; MAX_EAD_ITEMS],
 ) -> Result<BufferPlaintext2, EDHOCError> {
     let mut plaintext_2: BufferPlaintext2 = BufferPlaintext2::new();
     let c_r = c_r.as_cbor();
@@ -1042,17 +1037,17 @@ fn encode_plaintext_2(
     plaintext_2.content[1 + offset_cred..1 + offset_cred + mac_2.len()].copy_from_slice(&mac_2[..]);
     plaintext_2.len = 1 + offset_cred + mac_2.len();
 
-    if let Some(ead_2) = ead_2 {
-        match encode_ead_item(ead_2) {
-            Ok(ead_2) => plaintext_2
-                .extend_from_slice(ead_2.as_slice())
-                .and(Ok(plaintext_2))
-                .or(Err(EDHOCError::EadTooLongError)),
-            Err(e) => Err(e),
+    // Encode optional EAD_2
+    for ead in ead_2 {
+        if ead.value.is_some() {
+            let encoded = encode_ead_item(&ead)?;
+            plaintext_2
+                .extend_from_slice(encoded.as_slice())
+                .map_err(|_| EDHOCError::EadTooLongError)?;
         }
-    } else {
-        Ok(plaintext_2)
     }
+
+    Ok(plaintext_2)
 }
 
 /// Apply the XOR base encryption for ciphertext_2 in place. This will decrypt (or decrypt) the bytes
@@ -1205,14 +1200,16 @@ mod tests {
     // message with an array having too many cipher suites (more than 9)
     const MESSAGE_1_TV_SUITE_ONLY_ERR: &str = "038A02020202020202020202";
     const EAD_DUMMY_LABEL_TV: u16 = 0x01;
-    const EAD_DUMMY_VALUE_TV: &str = "cccccc";
-    const EAD_DUMMY_CRITICAL_TV: &str = "20cccccc";
+    const EAD_DUMMY_VALUE_TV: &str = "43cccccc";
+    const EAD_DUMMY_CRITICAL_TV: &str = "2043cccccc";
     const MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV: &str =
         "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b63701";
     const MESSAGE_1_WITH_DUMMY_EAD_TV: &str =
-        "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b63701cccccc";
+        "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370143cccccc";
     const MESSAGE_1_WITH_DUMMY_CRITICAL_EAD_TV: &str =
-        "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b63720cccccc";
+        "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6372043cccccc";
+    const MESSAGE_1_WITH_TWO_EADS: &str =
+        "0382060258208af6f430ebe18d34184017a9a11bf511c8dff8f834730b96c1b7c8dbca2fc3b6370143cccccc2043cccccc";
     const G_Y_TV: BytesP256ElemLen =
         hex!("419701d7f00a26c2dc587a36dd752549f33763c893422c8ea0f955a13a4ff5d5");
     #[allow(deprecated)]
@@ -1294,8 +1291,14 @@ mod tests {
     #[test]
     fn test_encode_message_1() {
         let suites_i_tv = EdhocBuffer::from_hex(SUITES_I_TV);
-        let message_1 =
-            encode_message_1(METHOD_TV, &suites_i_tv, &G_X_TV, C_I_TV, &None::<EADItem>).unwrap();
+        let message_1 = encode_message_1(
+            METHOD_TV,
+            &suites_i_tv,
+            &G_X_TV,
+            C_I_TV,
+            &EADItem::new_array(),
+        )
+        .unwrap();
 
         assert_eq!(message_1.len, 39);
         assert_eq!(message_1, BufferMessage1::from_hex(MESSAGE_1_TV));
@@ -1363,7 +1366,7 @@ mod tests {
         assert_eq!(suites_i, suites_i_tv_first_time);
         assert_eq!(g_x, G_X_TV_FIRST_TIME);
         assert_eq!(c_i, C_I_TV_FIRST_TIME);
-        assert!(ead_1.is_none());
+        assert!(ead_1[0].value.is_none());
 
         // second time message_1
         let res = parse_message_1(&message_1_tv);
@@ -1374,7 +1377,7 @@ mod tests {
         assert_eq!(suites_i, suites_i_tv);
         assert_eq!(g_x, G_X_TV);
         assert_eq!(c_i, C_I_TV);
-        assert!(ead_1.is_none());
+        assert!(ead_1[0].value.is_none());
     }
 
     #[test]
@@ -1523,7 +1526,7 @@ mod tests {
             &TH_3_TV,
             &ID_CRED_I_TV,
             &CRED_I_TV,
-            &None,
+            &EADItem::new_array(),
         );
         assert_eq!(mac_3, MAC_3_TV);
     }
@@ -1537,7 +1540,7 @@ mod tests {
             &ID_CRED_R_TV,
             &CRED_R_TV,
             &TH_2_TV,
-            &None,
+            &EADItem::new_array(),
         );
 
         assert_eq!(rcvd_mac_2, MAC_2_TV);
@@ -1552,7 +1555,7 @@ mod tests {
                 .unwrap()
                 .as_encoded_value(),
             &MAC_2_TV,
-            &None::<EADItem>,
+            &EADItem::new_array(),
         )
         .unwrap();
 
@@ -1580,7 +1583,7 @@ mod tests {
         assert_eq!(c_r, C_R_TV);
         assert_eq!(id_cred_r.as_full_value(), ID_CRED_R_TV);
         assert_eq!(mac_2, MAC_2_TV);
-        assert!(ead_2.is_none());
+        assert!(ead_2[0].value.is_none());
     }
 
     #[test]
@@ -1617,7 +1620,7 @@ mod tests {
         let plaintext_4 = decode_plaintext_4(&plaintext_4_tv);
         assert!(plaintext_4.is_ok());
         let ead_4 = plaintext_4.unwrap();
-        assert!(ead_4.is_none());
+        assert!(ead_4[0].value.is_none());
     }
 
     #[test]
@@ -1678,7 +1681,7 @@ mod tests {
                 .unwrap()
                 .as_encoded_value(),
             &MAC_3_TV,
-            &None::<EADItem>,
+            &EADItem::new_array(),
         )
         .unwrap();
         assert_eq!(plaintext_3, plaintext_3_tv);
@@ -1692,7 +1695,7 @@ mod tests {
 
         assert_eq!(mac_3, MAC_3_TV);
         assert_eq!(id_cred_i.as_full_value(), ID_CRED_I_TV);
-        assert!(ead_3.is_none());
+        assert!(ead_3[0].value.is_none());
     }
 
     #[test]
@@ -1723,7 +1726,10 @@ mod tests {
             value: Some(EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV)),
         };
 
-        let res = encode_message_1(method_tv, &suites_i_tv, &G_X_TV, c_i_tv, &Some(ead_item));
+        let mut ead_items = EADItem::new_array();
+        ead_items[0] = ead_item;
+
+        let res = encode_message_1(method_tv, &suites_i_tv, &G_X_TV, c_i_tv, &ead_items);
         assert!(res.is_ok());
         let message_1 = res.unwrap();
 
@@ -1738,7 +1744,7 @@ mod tests {
 
         // the actual value will be zeroed since it doesn't matter in this test
         let mut ead_value = EdhocMessageBuffer::new();
-        ead_value.len = MAX_MESSAGE_SIZE_LEN;
+        ead_value.len = MAX_MESSAGE_SIZE_LEN - 1;
 
         let ead_item = EADItem {
             label: EAD_DUMMY_LABEL_TV,
@@ -1746,7 +1752,10 @@ mod tests {
             value: Some(ead_value),
         };
 
-        let res = encode_message_1(method_tv, &suites_i_tv, &G_X_TV, c_i_tv, &Some(ead_item));
+        let mut ead_items = EADItem::new_array();
+        ead_items[0] = ead_item;
+
+        let res = encode_message_1(method_tv, &suites_i_tv, &G_X_TV, c_i_tv, &ead_items);
         assert_eq!(res.unwrap_err(), EDHOCError::EadTooLongError);
     }
 
@@ -1756,32 +1765,59 @@ mod tests {
         let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_TV);
         let ead_value_tv = EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV);
 
-        let res = parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]);
-        assert!(res.is_ok());
-        let ead_item = res.unwrap();
-        assert!(ead_item.is_some());
-        let ead_item = ead_item.unwrap();
+        let ead_items =
+            parse_eads(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
+
+        let ead_item = &ead_items[0];
         assert!(!ead_item.is_critical);
         assert_eq!(ead_item.label, EAD_DUMMY_LABEL_TV);
         assert_eq!(ead_item.value.unwrap().content, ead_value_tv.content);
+        // only 1 ead
+        for i in 1..MAX_EAD_ITEMS {
+            assert!(&ead_items[i].value.is_none());
+        }
 
         let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_CRITICAL_EAD_TV);
 
-        let res =
-            parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
-        let ead_item = res.unwrap();
+        let ead_items =
+            parse_eads(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
+
+        let ead_item = &ead_items[0];
         assert!(ead_item.is_critical);
         assert_eq!(ead_item.label, EAD_DUMMY_LABEL_TV);
         assert_eq!(ead_item.value.unwrap().content, ead_value_tv.content);
+        // only 1 ead
+        for i in 1..MAX_EAD_ITEMS {
+            assert!(&ead_items[i].value.is_none());
+        }
 
-        let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV);
+        let message_ead_tv: EdhocMessageBuffer =
+            BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_NO_VALUE_TV);
 
-        let res =
-            parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
-        let ead_item = res.unwrap();
+        let ead_items =
+            parse_eads(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
+        let ead_item = &ead_items[0];
         assert!(!ead_item.is_critical);
         assert_eq!(ead_item.label, EAD_DUMMY_LABEL_TV);
         assert!(ead_item.value.is_none());
+
+        let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_TWO_EADS);
+
+        let ead_items =
+            parse_eads(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]).unwrap();
+
+        let fst_ead = &ead_items[0];
+        assert!(!fst_ead.is_critical);
+        assert_eq!(fst_ead.label, EAD_DUMMY_LABEL_TV);
+        assert_eq!(fst_ead.value.unwrap().content, ead_value_tv.content);
+        let snd_ead = &ead_items[1];
+        assert!(snd_ead.is_critical);
+        assert_eq!(snd_ead.label, EAD_DUMMY_LABEL_TV);
+        assert_eq!(snd_ead.value.unwrap().content, ead_value_tv.content);
+        // 2 eads
+        for i in 2..MAX_EAD_ITEMS {
+            assert!(&ead_items[i].value.is_none());
+        }
     }
 
     #[test]
@@ -1792,7 +1828,8 @@ mod tests {
         let res = parse_message_1(&message_1_ead_tv);
         assert!(res.is_ok());
         let (_method, _suites_i, _g_x, _c_i, ead_1) = res.unwrap();
-        let ead_1 = ead_1.unwrap();
+
+        let ead_1 = &ead_1[0];
         assert!(ead_1.is_critical);
         assert_eq!(ead_1.label, EAD_DUMMY_LABEL_TV);
         assert_eq!(ead_1.value.unwrap().content, ead_value_tv.content);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -131,7 +131,14 @@ impl<Crypto: CryptoTrait> EdhocResponder<Crypto> {
     pub fn process_message_1(
         mut self,
         message_1: &BufferMessage1,
-    ) -> Result<(EdhocResponderProcessedM1<Crypto>, ConnId, Option<EADItem>), EDHOCError> {
+    ) -> Result<
+        (
+            EdhocResponderProcessedM1<Crypto>,
+            ConnId,
+            [EADItem; MAX_EAD_ITEMS],
+        ),
+        EDHOCError,
+    > {
         trace!("Enter process_message_1");
         let (state, c_i, ead_1) = r_process_message_1(&self.state, &mut self.crypto, message_1)?;
 
@@ -153,7 +160,7 @@ impl<Crypto: CryptoTrait> EdhocResponderProcessedM1<Crypto> {
         mut self,
         cred_transfer: CredentialTransfer,
         c_r: Option<ConnId>,
-        ead_2: &Option<EADItem>,
+        ead_2: &[EADItem; MAX_EAD_ITEMS],
     ) -> Result<(EdhocResponderWaitM3<Crypto>, BufferMessage2), EDHOCError> {
         trace!("Enter prepare_message_2");
         let c_r = match c_r {
@@ -186,7 +193,14 @@ impl<'a, Crypto: CryptoTrait> EdhocResponderWaitM3<Crypto> {
     pub fn parse_message_3(
         mut self,
         message_3: &'a BufferMessage3,
-    ) -> Result<(EdhocResponderProcessingM3<Crypto>, IdCred, Option<EADItem>), EDHOCError> {
+    ) -> Result<
+        (
+            EdhocResponderProcessingM3<Crypto>,
+            IdCred,
+            [EADItem; MAX_EAD_ITEMS],
+        ),
+        EDHOCError,
+    > {
         trace!("Enter parse_message_3");
         match r_parse_message_3(&mut self.state, &mut self.crypto, message_3) {
             Ok((state, id_cred_i, ead_3)) => Ok((
@@ -224,7 +238,7 @@ impl<'a, Crypto: CryptoTrait> EdhocResponderProcessingM3<Crypto> {
 impl<Crypto: CryptoTrait> EdhocResponderProcessedM3<Crypto> {
     pub fn prepare_message_4(
         mut self,
-        ead_4: &Option<EADItem>,
+        ead_4: &[EADItem; MAX_EAD_ITEMS],
     ) -> Result<(EdhocResponderDone<Crypto>, BufferMessage4), EDHOCError> {
         trace!("Enter prepare_message_4");
         match r_prepare_message_4(&self.state, &mut self.crypto, ead_4) {
@@ -311,7 +325,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiator<Crypto> {
     pub fn prepare_message_1(
         mut self,
         c_i: Option<ConnId>,
-        ead_1: &Option<EADItem>,
+        ead_1: &[EADItem; MAX_EAD_ITEMS],
     ) -> Result<(EdhocInitiatorWaitM2<Crypto>, EdhocMessageBuffer), EDHOCError> {
         trace!("Enter prepare_message_1");
         let c_i = match c_i {
@@ -351,7 +365,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorWaitM2<Crypto> {
             EdhocInitiatorProcessingM2<Crypto>,
             ConnId,
             IdCred,
-            Option<EADItem>,
+            [EADItem; MAX_EAD_ITEMS],
         ),
         EDHOCError,
     > {
@@ -410,7 +424,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorProcessedM2<Crypto> {
     pub fn prepare_message_3(
         mut self,
         cred_transfer: CredentialTransfer,
-        ead_3: &Option<EADItem>,
+        ead_3: &[EADItem; MAX_EAD_ITEMS],
     ) -> Result<
         (
             EdhocInitiatorWaitM4<Crypto>,
@@ -447,7 +461,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorWaitM4<Crypto> {
     pub fn process_message_4(
         mut self,
         message_4: &'a BufferMessage4,
-    ) -> Result<(EdhocInitiatorDone<Crypto>, Option<EADItem>), EDHOCError> {
+    ) -> Result<(EdhocInitiatorDone<Crypto>, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
         trace!("Enter parse_message_4");
         match i_process_message_4(&mut self.state, &mut self.crypto, message_4) {
             Ok((state, ead_4)) => Ok((
@@ -632,7 +646,7 @@ mod test {
         );
 
         let c_i = generate_connection_identifier_cbor(&mut default_crypto());
-        let result = initiator.prepare_message_1(Some(c_i), &None);
+        let result = initiator.prepare_message_1(Some(c_i), &EADItem::new_array());
         assert!(result.is_ok());
     }
 
@@ -693,7 +707,9 @@ mod test {
 
         // ---- begin initiator handling
         // if needed: prepare ead_1
-        let (initiator, message_1) = initiator.prepare_message_1(None, &None).unwrap();
+        let (initiator, message_1) = initiator
+            .prepare_message_1(None, &EADItem::new_array())
+            .unwrap();
         // ---- end initiator handling
 
         // ---- begin responder handling
@@ -701,7 +717,7 @@ mod test {
         // if ead_1: process ead_1
         // if needed: prepare ead_2
         let (responder, message_2) = responder
-            .prepare_message_2(CredentialTransfer::ByReference, None, &None)
+            .prepare_message_2(CredentialTransfer::ByReference, None, &EADItem::new_array())
             .unwrap();
         // ---- end responder handling
 
@@ -719,7 +735,7 @@ mod test {
 
         // if needed: prepare ead_3
         let (initiator, message_3, i_prk_out) = initiator
-            .prepare_message_3(CredentialTransfer::ByReference, &None)
+            .prepare_message_3(CredentialTransfer::ByReference, &EADItem::new_array())
             .unwrap();
         // ---- end initiator handling
 
@@ -729,7 +745,8 @@ mod test {
         let (responder, r_prk_out) = responder.verify_message_3(valid_cred_i).unwrap();
 
         // Send message_4
-        let (mut responder, message_4) = responder.prepare_message_4(&None).unwrap();
+        let (mut responder, message_4) =
+            responder.prepare_message_4(&EADItem::new_array()).unwrap();
         // ---- end responder handling
 
         let (mut initiator, _ead_4) = initiator.process_message_4(&message_4).unwrap();
@@ -830,11 +847,14 @@ mod test_authz {
             initiator.compute_ephemeral_secret(&device.g_w),
             initiator.selected_cipher_suite(),
         );
-        let (initiator, message_1) = initiator.prepare_message_1(None, &Some(ead_1)).unwrap();
+        let mut eads_1 = EADItem::new_array();
+        eads_1[0] = ead_1;
+        let (initiator, message_1) = initiator.prepare_message_1(None, &eads_1).unwrap();
         device.set_h_message_1(initiator.state.h_message_1.clone());
 
-        let (responder, _c_i, ead_1) = responder.process_message_1(&message_1).unwrap();
-        let ead_2 = if let Some(ead_1) = ead_1 {
+        let (responder, _c_i, eads_1) = responder.process_message_1(&message_1).unwrap();
+        let ead_2 = if eads_1[0].value.is_some() {
+            let ead_1 = &eads_1[0];
             let (authenticator, _loc_w, voucher_request) =
                 authenticator.process_ead_1(&ead_1, &message_1).unwrap();
 
@@ -845,9 +865,12 @@ mod test_authz {
 
             let res = authenticator.prepare_ead_2(&voucher_response);
             assert!(res.is_ok());
-            authenticator.prepare_ead_2(&voucher_response).ok()
+            let mut eads_2 = EADItem::new_array();
+            eads_2[0] = authenticator.prepare_ead_2(&voucher_response).unwrap();
+
+            eads_2
         } else {
-            None
+            EADItem::new_array()
         };
         let (responder, message_2) = responder
             .prepare_message_2(CredentialTransfer::ByValue, None, &ead_2)
@@ -856,8 +879,8 @@ mod test_authz {
         let (mut initiator, _c_r, id_cred_r, ead_2) =
             initiator.parse_message_2(&message_2).unwrap();
         let valid_cred_r = credential_check_or_fetch(None, id_cred_r).unwrap();
-        if let Some(ead_2) = ead_2 {
-            let result = device.process_ead_2(&mut default_crypto(), ead_2, CRED_R);
+        if ead_2[0].value.is_some() {
+            let result = device.process_ead_2(&mut default_crypto(), ead_2[0].clone(), CRED_R);
             assert!(result.is_ok());
         }
         initiator
@@ -869,7 +892,7 @@ mod test_authz {
         let initiator = initiator.verify_message_2(valid_cred_r).unwrap();
 
         let (initiator, message_3, i_prk_out) = initiator
-            .prepare_message_3(CredentialTransfer::ByReference, &None)
+            .prepare_message_3(CredentialTransfer::ByReference, &EADItem::new_array())
             .unwrap();
         let _initiator = initiator.completed_without_message_4();
         let (responder, id_cred_i, _ead_3) = responder.parse_message_3(&message_3).unwrap();

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -63,6 +63,7 @@ pub const MAC_LENGTH: usize = 8; // used for EAD Zeroconf
 pub const MAC_LENGTH_2: usize = MAC_LENGTH;
 pub const MAC_LENGTH_3: usize = MAC_LENGTH_2;
 pub const ENCODED_VOUCHER_LEN: usize = 1 + MAC_LENGTH; // 1 byte for the length of the bstr-encoded voucher
+pub const MAX_EAD_ITEMS: usize = 4;
 
 // maximum supported length of connection identifier for R
 //
@@ -488,7 +489,7 @@ pub struct ProcessingM2 {
     pub plaintext_2: EdhocMessageBuffer,
     pub c_r: ConnId,
     pub id_cred_r: IdCred,
-    pub ead_2: Option<EADItem>,
+    pub ead_2: [EADItem; MAX_EAD_ITEMS],
 }
 
 #[derive(Default, Debug)]
@@ -507,7 +508,7 @@ pub struct ProcessingM3 {
     pub th_3: BytesHashLen,
     pub id_cred_i: IdCred,
     pub plaintext_3: EdhocMessageBuffer,
-    pub ead_3: Option<EADItem>,
+    pub ead_3: [EADItem; MAX_EAD_ITEMS],
 }
 
 #[derive(Default, Debug)]
@@ -676,7 +677,7 @@ impl TryInto<EdhocMessageBuffer> for &[u8] {
 }
 
 #[cfg_attr(feature = "python-bindings", pyclass)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct EADItem {
     /// EAD label of the item
     ///
@@ -696,6 +697,10 @@ impl EADItem {
             is_critical: false,
             value: None,
         }
+    }
+
+    pub fn new_array() -> [EADItem; MAX_EAD_ITEMS] {
+        core::array::from_fn(|_| EADItem::new())
     }
 }
 
@@ -740,6 +745,108 @@ mod helpers {
 mod edhoc_parser {
     use super::*;
 
+    pub fn parse_eads(buffer: &[u8]) -> Result<[EADItem; MAX_EAD_ITEMS], EDHOCError> {
+        let mut count = 0;
+        let mut cursor = 0;
+        let mut eads = EADItem::new_array();
+
+        for _ in 0..MAX_EAD_ITEMS {
+            if !buffer[cursor..].is_empty() {
+                let (item, consumed) = parse_single_ead(&buffer[cursor..])?;
+                eads[count] = item;
+                count += 1;
+                cursor += consumed;
+            }
+        }
+
+        Ok(eads)
+    }
+
+    fn parse_single_ead(input: &[u8]) -> Result<(EADItem, usize), EDHOCError> {
+        let mut offset = 0;
+
+        let &label = input.get(offset).ok_or(EDHOCError::ParsingError)?;
+        offset += 1;
+
+        let (label, is_critical) = if CBORDecoder::is_u8(label) {
+            // CBOR unsigned integer (0..=23)
+            (label, false)
+        } else if CBORDecoder::is_i8(label) {
+            // CBOR negative integer (-1..=-24)
+            (label - (CBOR_NEG_INT_1BYTE_START - 1), true)
+        } else {
+            return Err(EDHOCError::ParsingError);
+        };
+
+        let ead_value = if let Some(&bstr_head) = input.get(offset) {
+            if (bstr_head & 0xe0) == 0x40 {
+                let additional_info = bstr_head & 0x1f;
+                offset += 1;
+
+                // Decode the length based on additional_info
+                let len = match additional_info {
+                    0..=23 => additional_info as usize,
+                    24 => {
+                        let len_byte = *input.get(offset).ok_or(EDHOCError::ParsingError)? as usize;
+                        offset += 1;
+                        len_byte
+                    }
+                    25 => {
+                        let len_bytes = input
+                            .get(offset..offset + 2)
+                            .ok_or(EDHOCError::ParsingError)?;
+                        offset += 2;
+                        u16::from_be_bytes(len_bytes.try_into().unwrap()) as usize
+                    }
+                    26 => {
+                        let len_bytes = input
+                            .get(offset..offset + 4)
+                            .ok_or(EDHOCError::ParsingError)?;
+                        offset += 4;
+                        u32::from_be_bytes(len_bytes.try_into().unwrap()) as usize
+                    }
+                    27 => {
+                        let len_bytes = input
+                            .get(offset..offset + 8)
+                            .ok_or(EDHOCError::ParsingError)?;
+                        offset += 8;
+                        let len_u64 = u64::from_be_bytes(len_bytes.try_into().unwrap());
+                        if len_u64 > usize::MAX as u64 {
+                            return Err(EDHOCError::ParsingError);
+                        }
+                        len_u64 as usize
+                    }
+                    _ => return Err(EDHOCError::ParsingError),
+                };
+
+                let bstr_bytes = input.get(1..offset + len).ok_or(EDHOCError::ParsingError)?;
+
+                let mut buf = EdhocMessageBuffer::new();
+                buf.fill_with_slice(bstr_bytes)
+                    .map_err(|_| EDHOCError::ParsingError)?;
+                buf.len = offset + len - 1;
+                offset += len;
+
+                Some(buf)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let item = EADItem {
+            label: label.into(),
+            is_critical,
+            value: ead_value,
+        };
+
+        Ok((item, offset))
+    }
+
+    #[deprecated(
+        note = "This API is only capable of parsing a single EAD, use parse_eads instead."
+    )]
     pub fn parse_ead(buffer: &[u8]) -> Result<Option<EADItem>, EDHOCError> {
         trace!("Enter parse_ead");
         // assuming label is a single byte integer (negative or positive)
@@ -820,7 +927,7 @@ mod edhoc_parser {
             EdhocBuffer<MAX_SUITES_LEN>,
             BytesP256ElemLen,
             ConnId,
-            Option<EADItem>,
+            [EADItem; MAX_EAD_ITEMS],
         ),
         EDHOCError,
     > {
@@ -835,18 +942,16 @@ mod edhoc_parser {
             // consume c_i encoded as single-byte int (we still do not support bstr encoding)
             let c_i = ConnId::from_decoder(&mut decoder)?;
 
-            // if there is still more to parse, the rest will be the EAD_1
+            // if there is still more to parse, the rest will be the EADs
             if rcvd_message_1.len > decoder.position() {
-                // NOTE: since the current implementation only supports one EAD handler,
-                // we assume only one EAD item
-                let ead_res = parse_ead(decoder.remaining_buffer()?);
-                if let Ok(ead_1) = ead_res {
-                    Ok((method, suites_i, g_x, c_i, ead_1))
+                let ead_res = parse_eads(decoder.remaining_buffer()?);
+                if let Ok(ead_buffer) = ead_res {
+                    Ok((method, suites_i, g_x, c_i, ead_buffer))
                 } else {
                     Err(ead_res.unwrap_err())
                 }
             } else if decoder.finished() {
-                Ok((method, suites_i, g_x, c_i, None))
+                Ok((method, suites_i, g_x, c_i, EADItem::new_array()))
             } else {
                 Err(EDHOCError::ParsingError)
             }
@@ -889,7 +994,7 @@ mod edhoc_parser {
 
     pub fn decode_plaintext_2(
         plaintext_2: &BufferCiphertext2,
-    ) -> Result<(ConnId, IdCred, BytesMac2, Option<EADItem>), EDHOCError> {
+    ) -> Result<(ConnId, IdCred, BytesMac2, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
         trace!("Enter decode_plaintext_2");
         let mut mac_2: BytesMac2 = [0x00; MAC_LENGTH_2];
 
@@ -902,17 +1007,16 @@ mod edhoc_parser {
 
         mac_2[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_2)?);
 
-        // if there is still more to parse, the rest will be the EAD_2
+        // if there is still more to parse, the rest will be the EADs
         if plaintext_2.len > decoder.position() {
-            // assume only one EAD item
-            let ead_res = parse_ead(decoder.remaining_buffer()?);
-            if let Ok(ead_2) = ead_res {
-                Ok((c_r, id_cred_r, mac_2, ead_2))
+            let ead_res = parse_eads(decoder.remaining_buffer()?);
+            if let Ok(ead2_buffer) = ead_res {
+                Ok((c_r, id_cred_r, mac_2, ead2_buffer))
             } else {
                 Err(ead_res.unwrap_err())
             }
         } else if decoder.finished() {
-            Ok((c_r, id_cred_r, mac_2, None))
+            Ok((c_r, id_cred_r, mac_2, EADItem::new_array()))
         } else {
             Err(EDHOCError::ParsingError)
         }
@@ -920,7 +1024,7 @@ mod edhoc_parser {
 
     pub fn decode_plaintext_3(
         plaintext_3: &BufferPlaintext3,
-    ) -> Result<(IdCred, BytesMac3, Option<EADItem>), EDHOCError> {
+    ) -> Result<(IdCred, BytesMac3, [EADItem; MAX_EAD_ITEMS]), EDHOCError> {
         trace!("Enter decode_plaintext_3");
         let mut mac_3: BytesMac3 = [0x00; MAC_LENGTH_3];
 
@@ -931,17 +1035,16 @@ mod edhoc_parser {
 
         mac_3[..].copy_from_slice(decoder.bytes_sized(MAC_LENGTH_3)?);
 
-        // if there is still more to parse, the rest will be the EAD_3
+        // if there is still more to parse, the rest will be the EADs
         if plaintext_3.len > decoder.position() {
-            // assume only one EAD item
-            let ead_res = parse_ead(decoder.remaining_buffer()?);
-            if let Ok(ead_3) = ead_res {
-                Ok((id_cred_i, mac_3, ead_3))
+            let ead_res = parse_eads(decoder.remaining_buffer()?);
+            if let Ok(ead3_buffer) = ead_res {
+                Ok((id_cred_i, mac_3, ead3_buffer))
             } else {
                 Err(ead_res.unwrap_err())
             }
         } else if decoder.finished() {
-            Ok((id_cred_i, mac_3, None))
+            Ok((id_cred_i, mac_3, EADItem::new_array()))
         } else {
             Err(EDHOCError::ParsingError)
         }
@@ -949,20 +1052,19 @@ mod edhoc_parser {
 
     pub fn decode_plaintext_4(
         plaintext_4: &BufferPlaintext4,
-    ) -> Result<Option<EADItem>, EDHOCError> {
+    ) -> Result<[EADItem; MAX_EAD_ITEMS], EDHOCError> {
         trace!("Enter decode_plaintext_4");
         let decoder = CBORDecoder::new(plaintext_4.as_slice());
 
         if plaintext_4.len > decoder.position() {
-            // assume only one EAD item
-            let ead_res = parse_ead(decoder.remaining_buffer()?);
-            if let Ok(ead_4) = ead_res {
-                Ok(ead_4)
+            let ead_res = parse_eads(decoder.remaining_buffer()?);
+            if let Ok(ead_4_buffer) = ead_res {
+                Ok(ead_4_buffer)
             } else {
                 Err(ead_res.unwrap_err())
             }
         } else if decoder.finished() {
-            Ok(None)
+            Ok(EADItem::new_array())
         } else {
             Err(EDHOCError::ParsingError)
         }

--- a/shared/src/python_bindings.rs
+++ b/shared/src/python_bindings.rs
@@ -70,6 +70,11 @@ impl EADItem {
     fn is_critical(&self) -> bool {
         self.is_critical
     }
+
+    #[staticmethod]
+    fn new_array_py() -> [Self; MAX_EAD_ITEMS] {
+        core::array::from_fn(|_| EADItem::new())
+    }
 }
 
 // FIXME: adjust for new Credential struct


### PR DESCRIPTION
**Request for Comments**

This PR is an initial step toward addressing issue #177. I'm experimenting with changing the internal representation of `EADItem` from an `Option` to a fixed-size array (`[EADItem; MAX_EAD_ITEMS]`). I chose 4 as a tentative maximum number of items, but that’s open for discussion.

I’m opening this early as a Request for Comments (RFC) to get feedback from folks with more context. In particular:

    This introduces significant breaking changes, replacing `Option<EADItem>` with `[EADItem; MAX_EAD_ITEMS]`.
    → Is it acceptable to move forward with this breaking change?
    → Or would it be better to maintain backward compatibility by duplicating the relevant APIs and deprecating the old ones?

Additionally, I could use some help with the C library integration — I wasn’t able to get it working yet (skill issues :cry: ).

Any thoughts, suggestions, or guidance would be greatly appreciated. Thanks in advance!