### PR TITLE
Configurable EAD buffer sizes

### DIFF
--- a/ead/lakers-ead-authz/src/authenticator.rs
+++ b/ead/lakers-ead-authz/src/authenticator.rs
@@ -170,7 +170,7 @@ mod test_authenticator {
     #[test]
     fn test_r_prepare_ead_2() {
         let voucher_response_tv: EdhocMessageBuffer = VOUCHER_RESPONSE_TV.try_into().unwrap();
-        let ead_2_value_tv: EdhocMessageBuffer = EAD2_VALUE_TV.try_into().unwrap();
+        let ead_2_value_tv: EADBuffer = EAD2_VALUE_TV.try_into().unwrap();
 
         let ead_authenticator = ZeroTouchAuthenticatorWaitVoucherResp::default();
 
@@ -179,7 +179,7 @@ mod test_authenticator {
             .unwrap();
         assert_eq!(ead_2.label, EAD_AUTHZ_LABEL);
         assert_eq!(ead_2.is_critical, true);
-        assert_eq!(ead_2.value.unwrap().content, ead_2_value_tv.content);
+        assert_eq!(ead_2.value.unwrap(), ead_2_value_tv);
     }
 }
 

--- a/ead/lakers-ead-authz/src/device.rs
+++ b/ead/lakers-ead-authz/src/device.rs
@@ -116,11 +116,8 @@ fn encrypt_enc_id<Crypto: CryptoTrait>(
     crypto.aes_ccm_encrypt_tag_8(&k_1, &iv_1, &enc_structure[..], plaintext)
 }
 
-fn encode_ead_1_value(
-    loc_w: &EdhocMessageBuffer,
-    enc_id: &EdhocMessageBuffer,
-) -> EdhocMessageBuffer {
-    let mut output = EdhocMessageBuffer::new();
+fn encode_ead_1_value(loc_w: &EdhocMessageBuffer, enc_id: &EdhocMessageBuffer) -> EADBuffer {
+    let mut output = EdhocBuffer::new();
 
     output.content[0] = CBOR_BYTE_STRING;
     // put length at output.content[1] after other sizes are known
@@ -176,7 +173,7 @@ mod test_device {
 
     #[test]
     fn test_prepare_ead_1() {
-        let ead_1_value_tv: EdhocMessageBuffer = EAD1_VALUE_TV.try_into().unwrap();
+        let ead_1_value_tv: EADBuffer = EAD1_VALUE_TV.try_into().unwrap();
 
         let ead_device = ZeroTouchDevice::new(
             ID_U_TV.try_into().unwrap(),
@@ -188,7 +185,7 @@ mod test_device {
             ead_device.prepare_ead_1(&mut default_crypto(), G_XW_TV.try_into().unwrap(), SS_TV);
         assert_eq!(ead_1.label, EAD_AUTHZ_LABEL);
         assert_eq!(ead_1.is_critical, true);
-        assert_eq!(ead_1.value.unwrap().content, ead_1_value_tv.content);
+        assert_eq!(ead_1.value.unwrap(), ead_1_value_tv);
     }
 
     #[test]

--- a/ead/lakers-ead-authz/src/shared.rs
+++ b/ead/lakers-ead-authz/src/shared.rs
@@ -66,7 +66,7 @@ pub(crate) fn compute_k_1_iv_1<Crypto: CryptoTrait>(
 }
 
 pub(crate) fn parse_ead_1_value(
-    value: &EdhocMessageBuffer,
+    value: &EADBuffer,
 ) -> Result<(EdhocMessageBuffer, EdhocMessageBuffer), EDHOCError> {
     let mut outer_decoder = CBORDecoder::new(value.as_slice());
     let voucher_info_seq = outer_decoder.bytes()?;

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -26,7 +26,7 @@ static HEAP: Heap = Heap::empty();
 pub struct EADItemC {
     pub label: u16,
     pub is_critical: bool,
-    pub value: EdhocMessageBuffer,
+    pub value: EADBuffer,
 }
 
 impl EADItemC {

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -493,8 +493,8 @@ pub fn i_complete_without_message_4(state: &WaitM4) -> Result<Completed, EDHOCEr
     })
 }
 
-fn encode_ead_item(ead_1: &EADItem) -> Result<EdhocMessageBuffer, EDHOCError> {
-    let mut output = EdhocMessageBuffer::new();
+fn encode_ead_item(ead_1: &EADItem) -> Result<EADBuffer, EDHOCError> {
+    let mut output = EdhocBuffer::new();
 
     // encode label
     // FIXME: This only works for values up to 23
@@ -1697,12 +1697,12 @@ mod tests {
 
     #[test]
     fn test_encode_ead_item() {
-        let ead_tv = EdhocMessageBuffer::from_hex(EAD_DUMMY_CRITICAL_TV);
+        let ead_tv = EdhocBuffer::from_hex(EAD_DUMMY_CRITICAL_TV);
 
         let ead_item = EADItem {
             label: EAD_DUMMY_LABEL_TV,
             is_critical: true,
-            value: Some(EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV)),
+            value: Some(EdhocBuffer::from_hex(EAD_DUMMY_VALUE_TV)),
         };
 
         let res = encode_ead_item(&ead_item);
@@ -1720,7 +1720,7 @@ mod tests {
         let ead_item = EADItem {
             label: EAD_DUMMY_LABEL_TV,
             is_critical: true,
-            value: Some(EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV)),
+            value: Some(EdhocBuffer::from_hex(EAD_DUMMY_VALUE_TV)),
         };
 
         let res = encode_message_1(method_tv, &suites_i_tv, &G_X_TV, c_i_tv, &Some(ead_item));
@@ -1737,8 +1737,8 @@ mod tests {
         let c_i_tv = C_I_TV;
 
         // the actual value will be zeroed since it doesn't matter in this test
-        let mut ead_value = EdhocMessageBuffer::new();
-        ead_value.len = MAX_MESSAGE_SIZE_LEN;
+        let mut ead_value = EdhocBuffer::new();
+        ead_value.len = MAX_EAD_SIZE_LEN;
 
         let ead_item = EADItem {
             label: EAD_DUMMY_LABEL_TV,
@@ -1754,7 +1754,7 @@ mod tests {
     fn test_parse_ead_item() {
         let message_tv_offset = MESSAGE_1_TV.len() / 2;
         let message_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_EAD_TV);
-        let ead_value_tv = EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV);
+        let ead_value_tv = EdhocBuffer::from_hex(EAD_DUMMY_VALUE_TV);
 
         let res = parse_ead(&message_ead_tv.content[message_tv_offset..message_ead_tv.len]);
         assert!(res.is_ok());
@@ -1787,7 +1787,7 @@ mod tests {
     #[test]
     fn test_parse_message_with_ead_item() {
         let message_1_ead_tv = BufferMessage1::from_hex(MESSAGE_1_WITH_DUMMY_CRITICAL_EAD_TV);
-        let ead_value_tv = EdhocMessageBuffer::from_hex(EAD_DUMMY_VALUE_TV);
+        let ead_value_tv = EdhocBuffer::from_hex(EAD_DUMMY_VALUE_TV);
 
         let res = parse_message_1(&message_1_ead_tv);
         assert!(res.is_ok());

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1738,7 +1738,7 @@ mod tests {
 
         // the actual value will be zeroed since it doesn't matter in this test
         let mut ead_value = EdhocBuffer::new();
-        ead_value.len = MAX_EAD_SIZE_LEN;
+        ead_value.len = MAX_EAD_LEN;
 
         let ead_item = EADItem {
             label: EAD_DUMMY_LABEL_TV,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -34,6 +34,7 @@ large_buffers = [
     "max_message_size_len_1024",
     "max_kdf_content_len_1024",
     "max_buffer_len_1024",
+    "max_ead_len_1024",
     "max_connid_encoded_len_24",
 ]
 
@@ -69,6 +70,19 @@ max_buffer_len_384 = []
 max_buffer_len_448 = []
 max_buffer_len_512 = []
 max_buffer_len_1024 = []
+
+## Precise control of `MAX_EAD_LEN`.
+##
+## If any of those is set, they override the default of 64. If multiple are
+## set, the highest wins.
+
+max_ead_len_128 = []
+max_ead_len_192 = []
+max_ead_len_256 = []
+max_ead_len_384 = []
+max_ead_len_512 = []
+max_ead_len_768 = []
+max_ead_len_1024 = []
 
 ## Control of `MAX_CONNID_ENCODED_LEN`.
 ##

--- a/shared/cbindgen.toml
+++ b/shared/cbindgen.toml
@@ -19,6 +19,7 @@ header = """
 #define _MAX_KDF_CONTENT_LEN_1024
 #define _MAX_BUFFER_LEN_1024
 #define _MAX_CONNID_ENCODED_LEN_24
+#define _MAX_EAD_LEN_1024
 #endif
 
 #if defined(_MAX_MESSAGE_SIZE_LEN_1024)
@@ -63,6 +64,24 @@ header = """
 #define MAX_BUFFER_LEN 256 + 64
 #endif
 
+#if defined(_MAX_EAD_LEN_1024)
+#define MAX_EAD_LEN 1024
+#elif defined(_MAX_EAD_LEN_768)
+#define MAX_EAD_LEN 768
+#elif defined(_MAX_EAD_LEN_512)
+#define MAX_EAD_LEN 512
+#elif defined(_MAX_EAD_LEN_384)
+#define MAX_EAD_LEN 384
+#elif defined(_MAX_EAD_LEN_256)
+#define MAX_EAD_LEN 256
+#elif defined(_MAX_EAD_LEN_192)
+#define MAX_EAD_LEN 192
+#elif defined(_MAX_EAD_LEN_128)
+#define MAX_EAD_LEN 128
+#else
+#define MAX_EAD_LEN 64
+#endif
+
 #if defined(_MAX_CONNID_ENCODED_LEN_24)
 #define MAX_CONNID_ENCODED_LEN 24
 #else
@@ -94,11 +113,19 @@ cpp_compat = true
 "feature = max_buffer_len_448" = "_MAX_BUFFER_LEN_448"
 "feature = max_buffer_len_512" = "_MAX_BUFFER_LEN_512"
 "feature = max_buffer_len_1024" = "_MAX_BUFFER_LEN_1024"
+"feature = max_ead_len_128" = "_MAX_EAD_LEN_128"
+"feature = max_ead_len_192" = "_MAX_EAD_LEN_192"
+"feature = max_ead_len_256" = "_MAX_EAD_LEN_256"
+"feature = max_ead_len_384" = "_MAX_EAD_LEN_384"
+"feature = max_ead_len_512" = "_MAX_EAD_LEN_512"
+"feature = max_ead_len_768" = "_MAX_EAD_LEN_768"
+"feature = max_ead_len_1024" = "_MAX_EAD_LEN_1024"
 "feature = max_connid_encoded_len_24" = "_MAX_CONNID_ENCODED_LEN_24"
 
 [export]
 include = [
     "EdhocMessageBuffer", "BytesMac", "BytesMac2",
+    "EADBuffer",
     "EADItemC",
     "EdhocBuffer", "BufferKid", "BufferCred", "BufferIdCred",
     "CredentialKey", "CredentialType", "IdCred",

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -119,7 +119,23 @@ pub const KID_LABEL: u8 = 4;
 
 pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
 
-pub const MAX_EAD_SIZE_LEN: usize = MAX_MESSAGE_SIZE_LEN;
+pub const MAX_EAD_LEN: usize = if cfg!(feature = "max_ead_len_1024") {
+    1024
+} else if cfg!(feature = "max_ead_len_768") {
+    768
+} else if cfg!(feature = "max_ead_len_512") {
+    512
+} else if cfg!(feature = "max_ead_len_384") {
+    384
+} else if cfg!(feature = "max_ead_len_256") {
+    256
+} else if cfg!(feature = "max_ead_len_192") {
+    192
+} else if cfg!(feature = "max_ead_len_128") {
+    128
+} else {
+    64
+};
 
 /// Maximum length of a [`ConnId`] (`C_x`).
 ///
@@ -166,7 +182,7 @@ pub type BytesEncStructureLen = [u8; ENC_STRUCTURE_LEN];
 
 pub type BytesMac = [u8; MAC_LENGTH];
 pub type BytesEncodedVoucher = [u8; ENCODED_VOUCHER_LEN];
-pub type EADBuffer = EdhocBuffer<MAX_EAD_SIZE_LEN>;
+pub type EADBuffer = EdhocBuffer<MAX_EAD_LEN>;
 
 /// Value of C_R or C_I, as chosen by ourself or the peer.
 ///

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -166,7 +166,7 @@ pub type BytesEncStructureLen = [u8; ENC_STRUCTURE_LEN];
 
 pub type BytesMac = [u8; MAC_LENGTH];
 pub type BytesEncodedVoucher = [u8; ENCODED_VOUCHER_LEN];
-pub type EADMessageBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD_SIZE_LEN
+pub type EADBuffer = EdhocMessageBuffer; // TODO: make it of size MAX_EAD_SIZE_LEN
 
 /// Value of C_R or C_I, as chosen by ourself or the peer.
 ///

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -650,7 +650,6 @@ mod edhoc_parser {
                     // EAD value is present
                     let mut buffer = EdhocMessageBuffer::new();
                     buffer.fill_with_slice(tail).unwrap(); // TODO(hax): this *should* not panic due to the buffer sizes passed from upstream functions. can we prove it with hax?
-                    buffer.len = tail.len();
                     Some(buffer)
                 } else {
                     None


### PR DESCRIPTION
This is a follow-up to https://github.com/openwsn-berkeley/lakers/pull/357#discussion_r2085078672 -- turns out there was really just one place where the EdhocMessageBuffer was (mis)used.

On the long run I'd prefer to get rid of this buffer altogether and instead work on owned message buffers (that might even be views onto an already buffered message), but that'll need larger API work, and this just changes types very locally.