### PR TITLE
buffer: Close API

### DIFF
--- a/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
@@ -37,13 +37,7 @@ impl CryptoTrait for Crypto {
         convert_array(&buffer[0..SHA256_DIGEST_LEN / 4])
     }
 
-    fn hkdf_expand(
-        &mut self,
-        prk: &BytesHashLen,
-        info: &BytesMaxInfoBuffer,
-        info_len: usize,
-        length: usize,
-    ) -> BytesMaxBuffer {
+    fn hkdf_expand(&mut self, prk: &BytesHashLen, info: &[u8], length: usize) -> BytesMaxBuffer {
         let mut buffer = [0x00u8; MAX_BUFFER_LEN];
         unsafe {
             CRYS_HKDF_KeyDerivFunc(
@@ -52,8 +46,9 @@ impl CryptoTrait for Crypto {
                 0 as usize,
                 prk.clone().as_mut_ptr(),
                 prk.len() as u32,
-                info.clone().as_mut_ptr(),
-                info_len as u32,
+                // Function does not write there, merely misses `const` in C
+                info.as_ptr() as *mut _,
+                info.len() as u32,
                 buffer.as_mut_ptr(),
                 length as u32,
                 SaSiBool_SASI_TRUE,

--- a/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
@@ -22,14 +22,15 @@ fn convert_array(input: &[u32]) -> [u8; SHA256_DIGEST_LEN] {
 pub struct Crypto;
 
 impl CryptoTrait for Crypto {
-    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+    fn sha256_digest(&mut self, message: &[u8]) -> BytesHashLen {
         let mut buffer: [u32; 64 / 4] = [0x00; 64 / 4];
 
         unsafe {
             CRYS_HASH(
                 CRYS_HASH_OperationMode_t_CRYS_HASH_SHA256_mode,
-                message.clone().as_mut_ptr(),
-                message_len,
+                // This just reads, the C code is missing a `const`.
+                message.as_ptr() as *mut _,
+                message.len(),
                 buffer.as_mut_ptr(),
             );
         }

--- a/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
@@ -83,6 +83,8 @@ impl CryptoTrait for Crypto {
         aesccm_key[0..AES_CCM_KEY_LEN].copy_from_slice(&key[..]);
         aesccm_ad[0..ad.len()].copy_from_slice(&ad[..]);
 
+        output.extend_reserve(plaintext.len()).unwrap();
+
         let _err = unsafe {
             CC_AESCCM(
                 SaSiAesEncryptMode_t_SASI_AES_ENCRYPT,
@@ -95,6 +97,8 @@ impl CryptoTrait for Crypto {
                 // CC_AESCCM does not really write there, it's just missing a `const`
                 plaintext.as_ptr() as *mut _,
                 plaintext.len() as u32,
+                #[allow(deprecated)]
+                // reason = "hax won't allow creating a .as_mut_slice() method"
                 output.content.as_mut_ptr(),
                 AES_CCM_TAG_LEN as u8, // authentication tag length
                 tag.as_mut_ptr(),
@@ -102,13 +106,12 @@ impl CryptoTrait for Crypto {
             )
         };
 
-        output.content[plaintext.len()..plaintext.len() + AES_CCM_TAG_LEN]
-            .copy_from_slice(&tag[..AES_CCM_TAG_LEN]);
-        output.len = plaintext.len() + AES_CCM_TAG_LEN;
+        output.extend_from_slice(&tag[..AES_CCM_TAG_LEN]).unwrap();
 
         output
     }
 
+    #[allow(deprecated)] // reason = "questionable use of buffer in API necessitates popping"
     fn aes_ccm_decrypt_tag_8<const N: usize>(
         &mut self,
         key: &BytesCcmKeyLen,
@@ -120,6 +123,8 @@ impl CryptoTrait for Crypto {
         let mut aesccm_key: CRYS_AESCCM_Key_t = Default::default();
 
         aesccm_key[0..AES_CCM_KEY_LEN].copy_from_slice(&key[..]);
+
+        assert!(ciphertext.len() - AES_CCM_TAG_LEN <= N);
 
         unsafe {
             match CC_AESCCM(

--- a/crypto/lakers-crypto-psa/src/lib.rs
+++ b/crypto/lakers-crypto-psa/src/lib.rs
@@ -101,13 +101,25 @@ impl CryptoTrait for Crypto {
         };
         let my_key = key_management::import(attributes, None, &key[..]).unwrap();
         let mut output_buffer = EdhocBuffer::new();
+        let full_range = output_buffer
+            .extend_reserve(plaintext.len() + AES_CCM_TAG_LEN)
+            .unwrap();
 
-        aead::encrypt(my_key, alg, iv, ad, plaintext, &mut output_buffer.content).unwrap();
+        #[allow(deprecated)] // reason = "using extend_reserve"
+        aead::encrypt(
+            my_key,
+            alg,
+            iv,
+            ad,
+            plaintext,
+            &mut output_buffer.content[full_range],
+        )
+        .unwrap();
 
-        output_buffer.len = plaintext.len() + AES_CCM_TAG_LEN;
         output_buffer
     }
 
+    #[allow(deprecated)] // reason = "questionable use of buffer in API necessitates popping"
     fn aes_ccm_decrypt_tag_8<const N: usize>(
         &mut self,
         key: &BytesCcmKeyLen,

--- a/crypto/lakers-crypto-psa/src/lib.rs
+++ b/crypto/lakers-crypto-psa/src/lib.rs
@@ -24,11 +24,11 @@ pub extern "C" fn mbedtls_hardware_poll(
 pub struct Crypto;
 
 impl CryptoTrait for Crypto {
-    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+    fn sha256_digest(&mut self, message: &[u8]) -> BytesHashLen {
         let hash_alg = Hash::Sha256;
         let mut hash: [u8; SHA256_DIGEST_LEN] = [0; SHA256_DIGEST_LEN];
         psa_crypto::init().unwrap();
-        hash_compute(hash_alg, &message[..message_len], &mut hash).unwrap();
+        hash_compute(hash_alg, message, &mut hash).unwrap();
 
         hash
     }
@@ -242,7 +242,7 @@ impl Crypto {
         s2[64..64 + message.len()].copy_from_slice(message);
 
         //    (4) apply H to the stream generated in step (3)
-        let ih = self.sha256_digest(&s2, 64 + message.len());
+        let ih = self.sha256_digest(&s2[..64 + message.len()]);
 
         //    (5) XOR (bitwise exclusive-OR) the B byte string computed in
         //        step (1) with opad
@@ -256,7 +256,7 @@ impl Crypto {
 
         //    (7) apply H to the stream generated in step (6) and output
         //        the result
-        let oh = self.sha256_digest(&s5, 3 * SHA256_DIGEST_LEN);
+        let oh = self.sha256_digest(&s5[..3 * SHA256_DIGEST_LEN]);
 
         oh
     }

--- a/crypto/lakers-crypto-rustcrypto/src/lib.rs
+++ b/crypto/lakers-crypto-rustcrypto/src/lib.rs
@@ -36,9 +36,9 @@ impl<Rng: rand_core::RngCore + rand_core::CryptoRng> core::fmt::Debug for Crypto
 }
 
 impl<Rng: rand_core::RngCore + rand_core::CryptoRng> CryptoTrait for Crypto<Rng> {
-    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen {
+    fn sha256_digest(&mut self, message: &[u8]) -> BytesHashLen {
         let mut hasher = sha2::Sha256::new();
-        hasher.update(&message[..message_len]);
+        hasher.update(message);
         hasher.finalize().into()
     }
 

--- a/crypto/lakers-crypto-rustcrypto/src/lib.rs
+++ b/crypto/lakers-crypto-rustcrypto/src/lib.rs
@@ -2,8 +2,8 @@
 
 use lakers_shared::{
     BufferCiphertext3, BufferPlaintext3, BytesCcmIvLen, BytesCcmKeyLen, BytesHashLen,
-    BytesMaxBuffer, BytesMaxInfoBuffer, BytesP256ElemLen, Crypto as CryptoTrait, EDHOCError,
-    AES_CCM_TAG_LEN, MAX_BUFFER_LEN,
+    BytesMaxBuffer, BytesP256ElemLen, Crypto as CryptoTrait, EDHOCError, AES_CCM_TAG_LEN,
+    MAX_BUFFER_LEN,
 };
 
 use ccm::AeadInPlace;
@@ -43,17 +43,11 @@ impl<Rng: rand_core::RngCore + rand_core::CryptoRng> CryptoTrait for Crypto<Rng>
         hasher.finalize().into()
     }
 
-    fn hkdf_expand(
-        &mut self,
-        prk: &BytesHashLen,
-        info: &BytesMaxInfoBuffer,
-        info_len: usize,
-        length: usize,
-    ) -> BytesMaxBuffer {
+    fn hkdf_expand(&mut self, prk: &BytesHashLen, info: &[u8], length: usize) -> BytesMaxBuffer {
         let hkdf =
             hkdf::Hkdf::<sha2::Sha256>::from_prk(prk).expect("Static size was checked at extract");
         let mut output: BytesMaxBuffer = [0; MAX_BUFFER_LEN];
-        hkdf.expand(&info[..info_len], &mut output[..length])
+        hkdf.expand(info, &mut output[..length])
             .expect("Static lengths match the algorithm");
         output
     }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -77,7 +77,7 @@ mod tests {
         let mut info = [0; MAX_INFO_LEN];
         info[..info_slice.len()].copy_from_slice(info_slice);
 
-        let okm = crypto.hkdf_expand(&prk, &info, info_slice.len(), output_length);
+        let okm = crypto.hkdf_expand(&prk, &info[..info_slice.len()], output_length);
         assert_eq!(okm[..output_length], expected_okm_slice[..]);
     }
 }

--- a/ead/lakers-ead-authz/src/authenticator.rs
+++ b/ead/lakers-ead-authz/src/authenticator.rs
@@ -12,7 +12,7 @@ impl ZeroTouchAuthenticator {
     pub fn process_ead_1(
         &self,
         ead_1: &EADItem,
-        message_1: &EdhocMessageBuffer,
+        message_1: &BufferMessage1,
     ) -> Result<
         (
             ZeroTouchAuthenticatorWaitVoucherResp,
@@ -56,7 +56,7 @@ impl ZeroTouchAuthenticatorWaitVoucherResp {
 }
 
 pub fn encode_voucher_request(
-    message_1: &EdhocMessageBuffer,
+    message_1: &BufferMessage1,
     opaque_state: &Option<EdhocMessageBuffer>,
 ) -> EdhocMessageBuffer {
     let mut output = EdhocMessageBuffer::new();
@@ -190,7 +190,7 @@ mod test_responder_stateless_operation {
 
     #[test]
     fn test_slo_encode_voucher_request() {
-        let message_1_tv: EdhocMessageBuffer = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
+        let message_1_tv = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
         let opaque_state_tv: EdhocMessageBuffer = SLO_OPAQUE_STATE_TV.try_into().unwrap();
         let voucher_request_tv: EdhocMessageBuffer = SLO_VOUCHER_REQUEST_TV.try_into().unwrap();
 

--- a/ead/lakers-ead-authz/src/authenticator.rs
+++ b/ead/lakers-ead-authz/src/authenticator.rs
@@ -28,7 +28,7 @@ impl ZeroTouchAuthenticator {
             return Err(EDHOCError::EADUnprocessable);
         }
 
-        let (loc_w, _enc_id) = parse_ead_1_value(&ead_1.value.unwrap())?;
+        let (loc_w, _enc_id) = parse_ead_1_value(ead_1.value.as_ref().unwrap())?;
         let voucher_request = encode_voucher_request(message_1, &opaque_state);
 
         Ok((

--- a/ead/lakers-ead-authz/src/authenticator.rs
+++ b/ead/lakers-ead-authz/src/authenticator.rs
@@ -61,22 +61,20 @@ pub fn encode_voucher_request(
 ) -> EdhocMessageBuffer {
     let mut output = EdhocMessageBuffer::new();
 
-    output.content[1] = CBOR_BYTE_STRING;
-    output.content[2] = message_1.len as u8;
-    output.content[3..3 + message_1.len].copy_from_slice(message_1.as_slice());
+    if opaque_state.is_some() {
+        output.push(CBOR_MAJOR_ARRAY | 2).unwrap();
+    } else {
+        output.push(CBOR_MAJOR_ARRAY | 1).unwrap();
+    }
+
+    output.push(CBOR_BYTE_STRING).unwrap();
+    output.push(message_1.len() as u8).unwrap();
+    output.extend_from_slice(message_1.as_slice()).unwrap();
 
     if let Some(opaque_state) = opaque_state {
-        output.content[0] = CBOR_MAJOR_ARRAY | 2;
-
-        output.content[3 + message_1.len] = CBOR_BYTE_STRING;
-        output.content[4 + message_1.len] = opaque_state.len as u8;
-        output.content[5 + message_1.len..5 + message_1.len + opaque_state.len]
-            .copy_from_slice(opaque_state.as_slice());
-
-        output.len = 5 + message_1.len + opaque_state.len;
-    } else {
-        output.content[0] = CBOR_MAJOR_ARRAY | 1;
-        output.len = 3 + message_1.len;
+        output.push(CBOR_BYTE_STRING).unwrap();
+        output.push(opaque_state.len() as u8).unwrap();
+        output.extend_from_slice(opaque_state.as_slice()).unwrap();
     }
 
     output

--- a/ead/lakers-ead-authz/src/authenticator.rs
+++ b/ead/lakers-ead-authz/src/authenticator.rs
@@ -126,8 +126,8 @@ mod test_authenticator {
         let res = parse_ead_1_value(&EAD1_VALUE_TV.try_into().unwrap());
         assert!(res.is_ok());
         let (loc_w, enc_id) = res.unwrap();
-        assert_eq!(loc_w.content, loc_w_tv.content);
-        assert_eq!(enc_id.content, enc_id_tv.content);
+        assert_eq!(loc_w, loc_w_tv);
+        assert_eq!(enc_id, enc_id_tv);
     }
 
     #[test]
@@ -136,7 +136,7 @@ mod test_authenticator {
 
         let voucher_request =
             encode_voucher_request(&MESSAGE_1_WITH_EAD_TV.try_into().unwrap(), &None);
-        assert_eq!(voucher_request.content, voucher_request_tv.content);
+        assert_eq!(voucher_request, voucher_request_tv);
     }
 
     #[test]
@@ -162,7 +162,7 @@ mod test_authenticator {
         let res = parse_voucher_response(&voucher_response_tv);
         assert!(res.is_ok());
         let (message_1, voucher, opaque_state) = res.unwrap();
-        assert_eq!(message_1.content, message_1_tv.content);
+        assert_eq!(message_1, message_1_tv);
         assert_eq!(voucher, voucher_tv);
         assert!(opaque_state.is_none());
     }
@@ -195,7 +195,7 @@ mod test_responder_stateless_operation {
         let voucher_request_tv: EdhocMessageBuffer = SLO_VOUCHER_REQUEST_TV.try_into().unwrap();
 
         let voucher_request = encode_voucher_request(&message_1_tv, &Some(opaque_state_tv));
-        assert_eq!(voucher_request.content, voucher_request_tv.content);
+        assert_eq!(voucher_request, voucher_request_tv);
     }
 
     #[test]
@@ -208,8 +208,8 @@ mod test_responder_stateless_operation {
         let res = parse_voucher_response(&voucher_response_tv);
         assert!(res.is_ok());
         let (message_1, voucher, opaque_state) = res.unwrap();
-        assert_eq!(message_1.content, message_1_tv.content);
+        assert_eq!(message_1, message_1_tv);
         assert_eq!(voucher, voucher_tv);
-        assert_eq!(opaque_state.unwrap().content, opaque_state_tv.content);
+        assert_eq!(opaque_state.unwrap(), opaque_state_tv);
     }
 }

--- a/ead/lakers-ead-authz/src/device.rs
+++ b/ead/lakers-ead-authz/src/device.rs
@@ -113,7 +113,7 @@ fn encrypt_enc_id<Crypto: CryptoTrait>(
     let enc_structure = encode_enc_structure(ss);
 
     // ENC_ID = 'ciphertext' of COSE_Encrypt0
-    crypto.aes_ccm_encrypt_tag_8(&k_1, &iv_1, &enc_structure[..], plaintext)
+    crypto.aes_ccm_encrypt_tag_8(&k_1, &iv_1, &enc_structure[..], plaintext.as_slice())
 }
 
 fn encode_ead_1_value(loc_w: &EdhocMessageBuffer, enc_id: &EdhocMessageBuffer) -> EADBuffer {

--- a/ead/lakers-ead-authz/src/device.rs
+++ b/ead/lakers-ead-authz/src/device.rs
@@ -168,7 +168,7 @@ mod test_device {
             &ID_U_ENCODED_TV.try_into().unwrap(),
             SS_TV,
         );
-        assert_eq!(enc_id.content, enc_id_tv.content);
+        assert_eq!(enc_id, enc_id_tv);
     }
 
     #[test]

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -138,7 +138,7 @@ fn decrypt_enc_id<Crypto: CryptoTrait>(
     let enc_structure = encode_enc_structure(ss);
 
     // ENC_ID = 'ciphertext' of COSE_Encrypt0
-    crypto.aes_ccm_decrypt_tag_8(&k_1, &iv_1, &enc_structure[..], &enc_id)
+    crypto.aes_ccm_decrypt_tag_8(&k_1, &iv_1, &enc_structure[..], enc_id.as_slice())
 }
 
 fn decode_id_u(id_u_bstr: EdhocMessageBuffer) -> Result<EdhocMessageBuffer, EDHOCError> {

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -41,11 +41,8 @@ impl ZeroTouchServer {
         let id_u_encoded = decrypt_enc_id(crypto, &prk, &enc_id, EDHOC_SUPPORTED_SUITES[0])?;
         let id_u = decode_id_u(id_u_encoded)?;
 
-        if self.acl.is_none() || self.authorized(id_u.content[3]) {
-            // compute hash
-            let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
-            message_1_buf[..message_1.len].copy_from_slice(message_1.as_slice());
-            let h_message_1 = crypto.sha256_digest(&message_1_buf, message_1.len);
+        if self.acl.is_none() || self.authorized(id_u[3]) {
+            let h_message_1 = crypto.sha256_digest(message_1.as_slice());
 
             let voucher = prepare_voucher(crypto, &h_message_1, &self.cred_v.as_slice(), &prk);
             let voucher_response = encode_voucher_response(&message_1, &voucher, &opaque_state);
@@ -96,10 +93,7 @@ impl ZeroTouchServerUserAcl {
         let (_method, _suites_i, g_x, _c_i, _ead_1) = parse_message_1(&message_1)?;
         let prk = compute_prk(crypto, &self.w, &g_x);
 
-        // compute hash
-        let mut message_1_buf: BytesMaxBuffer = [0x00; MAX_BUFFER_LEN];
-        message_1_buf[..message_1.len].copy_from_slice(message_1.as_slice());
-        let h_message_1 = crypto.sha256_digest(&message_1_buf, message_1.len);
+        let h_message_1 = crypto.sha256_digest(message_1.as_slice());
 
         let voucher = prepare_voucher(crypto, &h_message_1, &self.cred_v.as_slice(), &prk);
         let voucher_response = encode_voucher_response(&message_1, &voucher, &opaque_state);

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -194,7 +194,7 @@ mod test_enrollment_server {
             SS_TV,
         );
         assert!(id_u_res.is_ok());
-        assert_eq!(id_u_res.unwrap().content, id_u_encoded_tv.content);
+        assert_eq!(id_u_res.unwrap(), id_u_encoded_tv);
     }
 
     #[test]
@@ -216,7 +216,7 @@ mod test_enrollment_server {
 
         let voucher_response =
             encode_voucher_response(&message_1_tv, &voucher_tv, &Some(opaque_state_tv));
-        assert_eq!(voucher_response.content, voucher_response_tv.content);
+        assert_eq!(voucher_response, voucher_response_tv);
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod test_enrollment_server {
         let voucher_request = parse_voucher_request(&voucher_request_tv);
         assert!(voucher_request.is_ok());
         let (message_1, opaque_state) = voucher_request.unwrap();
-        assert_eq!(message_1.content, message_1_tv.content);
+        assert_eq!(message_1, message_1_tv);
         assert!(opaque_state.is_none());
     }
 
@@ -243,7 +243,7 @@ mod test_enrollment_server {
         );
         assert!(res.is_ok());
         let voucher_response = res.unwrap();
-        assert_eq!(voucher_response.content, voucher_response_tv.content);
+        assert_eq!(voucher_response, voucher_response_tv);
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod test_enrollment_server {
         );
         assert!(res.is_ok());
         let voucher_response = res.unwrap();
-        assert_eq!(voucher_response.content, voucher_response_tv.content);
+        assert_eq!(voucher_response, voucher_response_tv);
     }
 
     #[test]
@@ -300,7 +300,7 @@ mod test_enrollment_server_acl_user {
         );
         assert!(res.is_ok());
         let id_u = res.unwrap();
-        assert_eq!(id_u.content, id_u_tv.content);
+        assert_eq!(id_u, id_u_tv);
 
         let res = ead_server.prepare_voucher(
             &mut default_crypto(),
@@ -308,7 +308,7 @@ mod test_enrollment_server_acl_user {
         );
         assert!(res.is_ok());
         let voucher_response = res.unwrap();
-        assert_eq!(voucher_response.content, voucher_response_tv.content);
+        assert_eq!(voucher_response, voucher_response_tv);
     }
 }
 
@@ -327,8 +327,8 @@ mod test_server_stateless_operation {
         let voucher_request = parse_voucher_request(&voucher_request_tv);
         assert!(voucher_request.is_ok());
         let (message_1, opaque_state) = voucher_request.unwrap();
-        assert_eq!(message_1.content, message_1_tv.content);
-        assert_eq!(opaque_state.unwrap().content, opaque_state_tv.content);
+        assert_eq!(message_1, message_1_tv);
+        assert_eq!(opaque_state.unwrap(), opaque_state_tv);
     }
 
     #[test]
@@ -343,6 +343,6 @@ mod test_server_stateless_operation {
         );
         assert!(res.is_ok());
         let voucher_response = res.unwrap();
-        assert_eq!(voucher_response.content, voucher_response_tv.content);
+        assert_eq!(voucher_response, voucher_response_tv);
     }
 }

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -3,7 +3,7 @@ use defmt_or_log::trace;
 use lakers_shared::{Crypto as CryptoTrait, *};
 
 /// This server also stores an ACL
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct ZeroTouchServer {
     w: BytesP256ElemLen,            // private key of the enrollment server (W)
     pub cred_v: EdhocMessageBuffer, // credential of the authenticator (V)
@@ -18,9 +18,9 @@ impl ZeroTouchServer {
         ZeroTouchServer { w, cred_v, acl }
     }
 
-    pub fn authorized(self, kid: u8) -> bool {
-        if let Some(acl) = self.acl {
-            acl.content.contains(&kid)
+    pub fn authorized(&self, kid: u8) -> bool {
+        if let Some(acl) = self.acl.as_ref() {
+            acl.contains(&kid)
         } else {
             // if no acl then allow it
             true
@@ -57,7 +57,7 @@ impl ZeroTouchServer {
 }
 
 /// This server can be used when the ACL is stored in the application layer
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct ZeroTouchServerUserAcl {
     w: BytesP256ElemLen,            // private key of the enrollment server (W)
     pub cred_v: EdhocMessageBuffer, // credential of the authenticator (V)

--- a/ead/lakers-ead-authz/src/server.rs
+++ b/ead/lakers-ead-authz/src/server.rs
@@ -109,14 +109,14 @@ impl ZeroTouchServerUserAcl {
 
 fn parse_voucher_request(
     vreq: &EdhocMessageBuffer,
-) -> Result<(EdhocMessageBuffer, Option<EdhocMessageBuffer>), EDHOCError> {
+) -> Result<(BufferMessage1, Option<EdhocMessageBuffer>), EDHOCError> {
     let mut decoder = CBORDecoder::new(vreq.as_slice());
     let array_size = decoder.array()?;
     if array_size != 1 && array_size != 2 {
         return Err(EDHOCError::EADUnprocessable);
     }
 
-    let message_1: EdhocMessageBuffer = decoder.bytes()?.try_into().unwrap();
+    let message_1: BufferMessage1 = decoder.bytes()?.try_into().unwrap();
 
     if array_size == 2 {
         let opaque_state: EdhocMessageBuffer = decoder.bytes()?.try_into().unwrap();
@@ -149,7 +149,7 @@ fn decode_id_u(id_u_bstr: EdhocMessageBuffer) -> Result<EdhocMessageBuffer, EDHO
 }
 
 fn encode_voucher_response(
-    message_1: &EdhocMessageBuffer,
+    message_1: &BufferMessage1,
     voucher: &BytesEncodedVoucher,
     opaque_state: &Option<EdhocMessageBuffer>,
 ) -> EdhocMessageBuffer {
@@ -215,7 +215,7 @@ mod test_enrollment_server {
 
     #[test]
     fn test_encode_voucher_response() {
-        let message_1_tv: EdhocMessageBuffer = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
+        let message_1_tv = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
         let voucher_tv: BytesEncodedVoucher = VOUCHER_TV.try_into().unwrap();
         let opaque_state_tv: EdhocMessageBuffer = SLO_OPAQUE_STATE_TV.try_into().unwrap();
         let voucher_response_tv: EdhocMessageBuffer = SLO_VOUCHER_RESPONSE_TV.try_into().unwrap();
@@ -228,7 +228,7 @@ mod test_enrollment_server {
     #[test]
     fn test_parse_voucher_request() {
         let voucher_request_tv: EdhocMessageBuffer = VOUCHER_REQUEST_TV.try_into().unwrap();
-        let message_1_tv: EdhocMessageBuffer = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
+        let message_1_tv: BufferMessage1 = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
 
         let voucher_request = parse_voucher_request(&voucher_request_tv);
         assert!(voucher_request.is_ok());
@@ -327,7 +327,7 @@ mod test_server_stateless_operation {
     #[test]
     fn test_slo_parse_voucher_request() {
         let voucher_request_tv: EdhocMessageBuffer = SLO_VOUCHER_REQUEST_TV.try_into().unwrap();
-        let message_1_tv: EdhocMessageBuffer = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
+        let message_1_tv: BufferMessage1 = MESSAGE_1_WITH_EAD_TV.try_into().unwrap();
         let opaque_state_tv: EdhocMessageBuffer = SLO_OPAQUE_STATE_TV.try_into().unwrap();
 
         let voucher_request = parse_voucher_request(&voucher_request_tv);

--- a/ead/lakers-ead-authz/src/shared.rs
+++ b/ead/lakers-ead-authz/src/shared.rs
@@ -177,7 +177,7 @@ mod test_shared {
         let voucher_input_tv: EdhocMessageBuffer = VOUCHER_INPUT_TV.try_into().unwrap();
 
         let voucher_input = encode_voucher_input(&h_message_1_tv, &CRED_V_TV);
-        assert_eq!(voucher_input.content, voucher_input_tv.content);
+        assert_eq!(voucher_input, voucher_input_tv);
     }
 
     #[test]

--- a/ead/lakers-ead-authz/src/shared.rs
+++ b/ead/lakers-ead-authz/src/shared.rs
@@ -92,17 +92,15 @@ pub(crate) fn encode_enc_structure(ss: u8) -> [u8; EAD_AUTHZ_ENC_STRUCTURE_LEN] 
 fn encode_voucher_input(h_message_1: &BytesHashLen, cred_v: &[u8]) -> EdhocMessageBuffer {
     let mut voucher_input = EdhocMessageBuffer::new();
 
-    voucher_input.content[0] = CBOR_BYTE_STRING;
-    voucher_input.content[1] = SHA256_DIGEST_LEN as u8;
-    voucher_input.content[2..2 + SHA256_DIGEST_LEN]
-        .copy_from_slice(&h_message_1[..SHA256_DIGEST_LEN]);
+    voucher_input.push(CBOR_BYTE_STRING).unwrap();
+    voucher_input.push(SHA256_DIGEST_LEN as u8).unwrap();
+    voucher_input
+        .extend_from_slice(&h_message_1[..SHA256_DIGEST_LEN])
+        .unwrap();
 
-    voucher_input.content[2 + SHA256_DIGEST_LEN] = CBOR_BYTE_STRING;
-    voucher_input.content[3 + SHA256_DIGEST_LEN] = cred_v.len() as u8;
-    voucher_input.content[4 + SHA256_DIGEST_LEN..4 + SHA256_DIGEST_LEN + cred_v.len()]
-        .copy_from_slice(cred_v);
-
-    voucher_input.len = 4 + SHA256_DIGEST_LEN + cred_v.len();
+    voucher_input.push(CBOR_BYTE_STRING).unwrap();
+    voucher_input.push(cred_v.len() as u8).unwrap();
+    voucher_input.extend_from_slice(cred_v).unwrap();
 
     voucher_input
 }

--- a/ead/lakers-ead-authz/src/shared.rs
+++ b/ead/lakers-ead-authz/src/shared.rs
@@ -136,7 +136,7 @@ fn edhoc_kdf_expand<Crypto: CryptoTrait>(
     length: usize,
 ) -> BytesMaxBuffer {
     let (info, info_len) = encode_info(label, context, length);
-    let output = crypto.hkdf_expand(prk, &info, info_len, length);
+    let output = crypto.hkdf_expand(prk, &info[..info_len], length);
     output
 }
 

--- a/examples/coap/src/bin/coapclient.rs
+++ b/examples/coap/src/bin/coapclient.rs
@@ -53,7 +53,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     println!("response_vec = {:02x?}", response.message.payload);
     println!("message_2 len = {}", response.message.payload.len());
 
-    let message_2 = EdhocMessageBuffer::new_from_slice(&response.message.payload[..]).unwrap();
+    let message_2 = EdhocBuffer::new_from_slice(&response.message.payload[..]).unwrap();
     let (mut initiator, c_r, id_cred_r, _ead_2) = initiator.parse_message_2(&message_2)?;
     let valid_cred_r = credential_check_or_fetch(Some(cred_r), id_cred_r).unwrap();
     initiator.set_identity(I.try_into().unwrap(), cred_i)?;
@@ -71,7 +71,7 @@ fn client_handshake() -> Result<(), EDHOCError> {
     }
     println!("response_vec = {:02x?}", response.message.payload);
     println!("message_3 len = {}", response.message.payload.len());
-    let message_4 = EdhocMessageBuffer::new_from_slice(&response.message.payload[..]).unwrap();
+    let message_4 = EdhocBuffer::new_from_slice(&response.message.payload[..]).unwrap();
     let (mut initiator, _ead_4) = initiator.process_message_4(&message_4).unwrap();
 
     println!("EDHOC exchange successfully completed");

--- a/examples/coap/src/bin/coapserver-coaphandler.rs
+++ b/examples/coap/src/bin/coapserver-coaphandler.rs
@@ -112,7 +112,7 @@ impl coap_handler::Handler for EdhocHandler {
                     .expect("Static credential is not processable");
 
             let message_1 =
-                &EdhocMessageBuffer::new_from_slice(&request.payload()[1..]).map_err(too_small)?;
+                &EdhocBuffer::new_from_slice(&request.payload()[1..]).map_err(too_small)?;
 
             let (responder, _c_i, ead_1) = EdhocResponder::new(
                 lakers_crypto::default_crypto(),
@@ -173,7 +173,7 @@ impl coap_handler::Handler for EdhocHandler {
 
             println!("Found state with connection identifier {:?}", c_r_rcvd);
 
-            let message_3 = EdhocMessageBuffer::new_from_slice(&message_3).map_err(too_small)?;
+            let message_3 = EdhocBuffer::new_from_slice(&message_3).map_err(too_small)?;
             let result = responder.parse_message_3(&message_3);
             let (responder, id_cred_i, _ead_3) = result.map_err(|e| {
                 println!("EDHOC processing error: {:?}", e);

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -52,7 +52,7 @@ fn main() {
                     cred_r,
                 );
 
-                let message_1: EdhocMessageBuffer = request.message.payload[1..]
+                let message_1: BufferMessage1 = request.message.payload[1..]
                     .try_into()
                     .expect("wrong length");
                 let result = responder.process_message_1(&message_1);
@@ -98,8 +98,7 @@ fn main() {
                 let responder = take_state(c_r_rcvd, &mut edhoc_connections).unwrap();
 
                 println!("Found state with connection identifier {:?}", c_r_rcvd);
-                let message_3 =
-                    EdhocMessageBuffer::new_from_slice(&request.message.payload[1..]).unwrap();
+                let message_3 = EdhocBuffer::new_from_slice(&request.message.payload[1..]).unwrap();
                 let Ok((responder, id_cred_i, _ead_3)) = responder.parse_message_3(&message_3)
                 else {
                     println!("EDHOC error at parse_message_3: {:?}", message_3);

--- a/examples/coap/src/bin/coapserver.rs
+++ b/examples/coap/src/bin/coapserver.rs
@@ -108,7 +108,9 @@ fn main() {
                 };
                 let cred_i = Credential::parse_ccs(CRED_I.try_into().unwrap()).unwrap();
                 let valid_cred_i = credential_check_or_fetch(Some(cred_i), id_cred_i).unwrap();
-                let Ok((responder, prk_out)) = responder.verify_message_3(valid_cred_i) else {
+                // FIXME: instead of cloning, take by reference
+                let Ok((responder, prk_out)) = responder.verify_message_3(valid_cred_i.clone())
+                else {
                     println!("EDHOC error at verify_message_3: {:?}", valid_cred_i);
                     continue;
                 };

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -31,7 +31,7 @@ pub struct EADItemC {
 
 impl EADItemC {
     pub fn to_rust(&self) -> EADItem {
-        let value = Some(self.value);
+        let value = Some(self.value.clone());
 
         EADItem {
             label: self.label,
@@ -87,7 +87,7 @@ impl ProcessingM2C {
             th_2: self.th_2,
             x: self.x,
             g_y: self.g_y,
-            plaintext_2: self.plaintext_2,
+            plaintext_2: self.plaintext_2.clone(),
             #[allow(deprecated)]
             c_r: ConnId::from_int_raw(self.c_r),
             id_cred_r: self.id_cred_r.clone(),
@@ -118,7 +118,7 @@ impl ProcessingM2C {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct CredentialC {
     pub bytes: BufferCred,
@@ -133,9 +133,9 @@ pub struct CredentialC {
 impl CredentialC {
     pub fn to_rust(&self) -> Credential {
         Credential {
-            bytes: self.bytes,
+            bytes: self.bytes.clone(),
             key: self.key,
-            kid: Some(self.kid),
+            kid: Some(self.kid.clone()),
             cred_type: self.cred_type,
         }
     }
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn credential_check_or_fetch(
         Some((*cred_expected).to_rust())
     };
 
-    let id_cred_received_value = *id_cred_received;
+    let id_cred_received_value = (*id_cred_received).clone();
     match credential_check_or_fetch_rust(cred_expected, id_cred_received_value) {
         Ok(valid_cred) => {
             CredentialC::copy_into_c(valid_cred, cred_out);

--- a/lakers-python/src/ead_authz/authenticator.rs
+++ b/lakers-python/src/ead_authz/authenticator.rs
@@ -29,7 +29,7 @@ impl PyAuthzAutenticator {
         ead_1: EADItem,
         message_1: Vec<u8>,
     ) -> PyResult<(Bound<'a, PyString>, Bound<'a, PyBytes>)> {
-        let message_1 = EdhocMessageBuffer::new_from_slice(message_1.as_slice())?;
+        let message_1 = EdhocBuffer::new_from_slice(message_1.as_slice())?;
         let (state, loc_w, voucher_request) =
             self.authenticator.process_ead_1(&ead_1, &message_1)?;
         self.authenticator_wait = state;

--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -106,7 +106,7 @@ impl PyEdhocInitiator {
         py: Python<'a>,
         message_2: Vec<u8>,
     ) -> PyResult<(Bound<'a, PyBytes>, Bound<'a, PyBytes>, Option<EADItem>)> {
-        let message_2 = EdhocMessageBuffer::new_from_slice(message_2.as_slice())
+        let message_2 = EdhocBuffer::new_from_slice(message_2.as_slice())
             .with_cause(py, "Message 2 too long")?;
 
         let (state, c_r, id_cred_r, ead_2) =
@@ -195,7 +195,7 @@ impl PyEdhocInitiator {
         py: Python<'a>,
         message_4: Vec<u8>,
     ) -> PyResult<Option<EADItem>> {
-        let message_4 = EdhocMessageBuffer::new_from_slice(message_4.as_slice())
+        let message_4 = EdhocBuffer::new_from_slice(message_4.as_slice())
             .with_cause(py, "Message 4 too long")?;
         let (state, ead_4) =
             i_process_message_4(&mut self.take_wait_m4()?, &mut default_crypto(), &message_4)?;

--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -165,7 +165,8 @@ impl PyEdhocInitiator {
         let (state, message_3, prk_out) = i_prepare_message_3(
             &mut self.take_processed_m2()?,
             &mut default_crypto(),
-            self.cred_i.unwrap(),
+            // FIXME: take as reference rather than cloning
+            self.cred_i.as_ref().unwrap().clone(),
             cred_transfer,
             &ead_3,
         )?;

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -79,7 +79,7 @@ impl PyEdhocResponder {
         py: Python<'a>,
         message_1: Vec<u8>,
     ) -> PyResult<(Bound<'a, PyBytes>, Option<EADItem>)> {
-        let message_1 = EdhocMessageBuffer::new_from_slice(message_1.as_slice())
+        let message_1 = EdhocBuffer::new_from_slice(message_1.as_slice())
             .with_cause(py, "Message 1 too long")?;
         let (state, c_i, ead_1) =
             r_process_message_1(&self.take_start()?, &mut default_crypto(), &message_1)?;
@@ -133,7 +133,7 @@ impl PyEdhocResponder {
         py: Python<'a>,
         message_3: Vec<u8>,
     ) -> PyResult<(Bound<'a, PyBytes>, Option<EADItem>)> {
-        let message_3 = EdhocMessageBuffer::new_from_slice(message_3.as_slice())
+        let message_3 = EdhocBuffer::new_from_slice(message_3.as_slice())
             .with_cause(py, "Message 3 too long")?;
         let (state, id_cred_i, ead_3) =
             r_parse_message_3(&mut self.take_wait_m3()?, &mut default_crypto(), &message_3)?;

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -112,7 +112,8 @@ impl PyEdhocResponder {
         let (state, message_2) = r_prepare_message_2(
             self.as_ref_processing_m1()?,
             &mut default_crypto(),
-            self.cred_r,
+            // FIXME: take as reference rather than cloning
+            self.cred_r.clone(),
             &r,
             c_r,
             cred_transfer,

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -448,8 +448,7 @@ fn encode_ead_item(ead_1: &EADItem) -> Result<EADBuffer, EDHOCError> {
     };
 
     if let Some(label) = res {
-        output.content[0] = label;
-        output.len = 1;
+        output.push(label).unwrap();
 
         // encode value
         if let Some(ead_1_value) = &ead_1.value {
@@ -474,43 +473,36 @@ fn encode_message_1(
     ead_1: &Option<EADItem>,
 ) -> Result<BufferMessage1, EDHOCError> {
     let mut output = BufferMessage1::new();
-    let mut raw_suites_len: usize = 0;
 
-    output.content[0] = method; // CBOR unsigned int less than 24 is encoded verbatim
+    output.push(method).unwrap(); // CBOR unsigned int less than 24 is encoded verbatim
 
-    if suites.len == 1 {
+    if suites.len() == 1 {
         // only one suite, will be encoded as a single integer
         if suites[0] <= CBOR_UINT_1BYTE {
-            output.content[1] = suites[0];
-            raw_suites_len = 1;
+            output.push(suites[0]).unwrap();
         } else {
-            output.content[1] = CBOR_UINT_1BYTE;
-            output.content[2] = suites[0]; // assume it is smaller than 255, which all suites are
-            raw_suites_len = 2;
+            output.push(CBOR_UINT_1BYTE).unwrap();
+            output.push(suites[0]).unwrap(); // assume it is smaller than 255, which all suites are
         }
     } else {
         // several suites, will be encoded as an array
-        output.content[1] = CBOR_MAJOR_ARRAY + (suites.len as u8);
-        raw_suites_len += 1;
+        output
+            .push(CBOR_MAJOR_ARRAY + (suites.len() as u8))
+            .unwrap();
         for &suite in suites.as_slice().iter() {
             if suite <= CBOR_UINT_1BYTE {
-                output.content[1 + raw_suites_len] = suite;
-                raw_suites_len += 1;
+                output.push(suite).unwrap();
             } else {
-                output.content[1 + raw_suites_len] = CBOR_UINT_1BYTE;
-                output.content[2 + raw_suites_len] = suite;
-                raw_suites_len += 2;
+                output.push(CBOR_UINT_1BYTE).unwrap();
+                output.push(suite).unwrap();
             }
         }
     };
 
-    output.content[1 + raw_suites_len] = CBOR_BYTE_STRING; // CBOR byte string magic number
-    output.content[2 + raw_suites_len] = P256_ELEM_LEN as u8; // length of the byte string
-    output.content[3 + raw_suites_len..3 + raw_suites_len + P256_ELEM_LEN]
-        .copy_from_slice(&g_x[..]);
-    let c_i = c_i.as_cbor();
-    output.len = 3 + raw_suites_len + P256_ELEM_LEN + c_i.len();
-    output.content[3 + raw_suites_len + P256_ELEM_LEN..][..c_i.len()].copy_from_slice(c_i);
+    output.push(CBOR_BYTE_STRING).unwrap(); // CBOR byte string magic number
+    output.push(P256_ELEM_LEN as u8).unwrap(); // length of the byte string
+    output.extend_from_slice(&g_x[..]).unwrap();
+    output.extend_from_slice(c_i.as_cbor()).unwrap();
 
     if let Some(ead_1) = ead_1 {
         match encode_ead_item(ead_1) {
@@ -528,13 +520,13 @@ fn encode_message_1(
 fn encode_message_2(g_y: &BytesP256ElemLen, ciphertext_2: &BufferCiphertext2) -> BufferMessage2 {
     let mut output: BufferMessage2 = BufferMessage2::new();
 
-    output.content[0] = CBOR_BYTE_STRING;
-    output.content[1] = P256_ELEM_LEN as u8 + ciphertext_2.len as u8;
-    output.content[2..2 + P256_ELEM_LEN].copy_from_slice(&g_y[..]);
-    output.content[2 + P256_ELEM_LEN..2 + P256_ELEM_LEN + ciphertext_2.len]
-        .copy_from_slice(ciphertext_2.as_slice());
+    output.push(CBOR_BYTE_STRING).unwrap();
+    output
+        .push(P256_ELEM_LEN as u8 + ciphertext_2.len() as u8)
+        .unwrap();
+    output.extend_from_slice(g_y).unwrap();
+    output.extend_from_slice(ciphertext_2.as_slice()).unwrap();
 
-    output.len = 2 + P256_ELEM_LEN + ciphertext_2.len;
     output
 }
 
@@ -566,12 +558,12 @@ fn compute_th_3(
     message[0] = CBOR_BYTE_STRING;
     message[1] = th_2.len() as u8;
     message[2..2 + th_2.len()].copy_from_slice(&th_2[..]);
-    message[2 + th_2.len()..2 + th_2.len() + plaintext_2.len]
+    message[2 + th_2.len()..2 + th_2.len() + plaintext_2.len()]
         .copy_from_slice(plaintext_2.as_slice());
-    message[2 + th_2.len() + plaintext_2.len..2 + th_2.len() + plaintext_2.len + cred_r.len()]
+    message[2 + th_2.len() + plaintext_2.len()..2 + th_2.len() + plaintext_2.len() + cred_r.len()]
         .copy_from_slice(cred_r);
 
-    crypto.sha256_digest(&message[..th_2.len() + 2 + plaintext_2.len + cred_r.len()])
+    crypto.sha256_digest(&message[..th_2.len() + 2 + plaintext_2.len() + cred_r.len()])
 }
 
 fn compute_th_4(
@@ -585,12 +577,12 @@ fn compute_th_4(
     message[0] = CBOR_BYTE_STRING;
     message[1] = th_3.len() as u8;
     message[2..2 + th_3.len()].copy_from_slice(&th_3[..]);
-    message[2 + th_3.len()..2 + th_3.len() + plaintext_3.len]
+    message[2 + th_3.len()..2 + th_3.len() + plaintext_3.len()]
         .copy_from_slice(plaintext_3.as_slice());
-    message[2 + th_3.len() + plaintext_3.len..2 + th_3.len() + plaintext_3.len + cred_i.len()]
+    message[2 + th_3.len() + plaintext_3.len()..2 + th_3.len() + plaintext_3.len() + cred_i.len()]
         .copy_from_slice(cred_i);
 
-    crypto.sha256_digest(&message[..th_3.len() + 2 + plaintext_3.len + cred_i.len()])
+    crypto.sha256_digest(&message[..th_3.len() + 2 + plaintext_3.len() + cred_i.len()])
 }
 
 // TODO: consider moving this to a new 'edhoc crypto primitives' module
@@ -611,26 +603,22 @@ fn encode_plaintext_3(
     mac_3: &BytesMac3,
     ead_3: &Option<EADItem>,
 ) -> Result<BufferPlaintext3, EDHOCError> {
-    let mut plaintext_3: BufferPlaintext3 = BufferPlaintext3::new();
-
     // plaintext: P = ( ? PAD, ID_CRED_I / bstr / int, Signature_or_MAC_3, ? EAD_3 )
-    // id_cred_i.write_to_message(&mut plaintext_3)?;
+    let mut plaintext_3 =
+        BufferPlaintext3::new_from_slice(id_cred_i).or(Err(EDHOCError::EncodingError))?;
     plaintext_3
-        .extend_from_slice(id_cred_i)
+        .push(CBOR_MAJOR_BYTE_STRING | MAC_LENGTH_3 as u8)
         .or(Err(EDHOCError::EncodingError))?;
-    let offset_cred = plaintext_3.len;
-    plaintext_3.content[offset_cred] = CBOR_MAJOR_BYTE_STRING | MAC_LENGTH_3 as u8;
-    plaintext_3.content[offset_cred + 1..][..mac_3.len()].copy_from_slice(&mac_3[..]);
-    plaintext_3.len = offset_cred + 1 + mac_3.len();
+    plaintext_3
+        .extend_from_slice(mac_3)
+        .or(Err(EDHOCError::EncodingError))?;
 
     if let Some(ead_3) = ead_3 {
-        match encode_ead_item(ead_3) {
-            Ok(ead_3) => plaintext_3
-                .extend_from_slice(ead_3.as_slice())
-                .and(Ok(plaintext_3))
-                .or(Err(EDHOCError::EadTooLongError)),
-            Err(e) => Err(e),
-        }
+        let ead_3 = encode_ead_item(ead_3)?;
+        plaintext_3
+            .extend_from_slice(ead_3.as_slice())
+            .and(Ok(plaintext_3))
+            .or(Err(EDHOCError::EadTooLongError))
     } else {
         Ok(plaintext_3)
     }
@@ -727,22 +715,21 @@ fn encrypt_message_3(
     plaintext_3: &BufferPlaintext3,
 ) -> BufferMessage3 {
     let mut output: BufferMessage3 = BufferMessage3::new();
-    let bytestring_length = plaintext_3.len + AES_CCM_TAG_LEN;
-    let prefix_length;
+    let bytestring_length = plaintext_3.len() + AES_CCM_TAG_LEN;
     // FIXME: Reuse CBOR encoder
     if bytestring_length < 24 {
-        output.content[0] = CBOR_MAJOR_BYTE_STRING | (bytestring_length) as u8;
-        prefix_length = 1;
+        output
+            .push(CBOR_MAJOR_BYTE_STRING | (bytestring_length) as u8)
+            .unwrap();
     } else {
         // FIXME: Assumes we don't exceed 256 bytes which is the current buffer size
-        output.content[0] = CBOR_MAJOR_BYTE_STRING | 24;
-        output.content[1] = bytestring_length as _;
-        prefix_length = 2;
+        output.push(CBOR_MAJOR_BYTE_STRING | 24).unwrap();
+        output.push(bytestring_length as _).unwrap();
     };
-    output.len = prefix_length + bytestring_length;
+
     // FIXME: Make the function fallible, especially with the prospect of algorithm agility
     assert!(
-        output.len <= MAX_MESSAGE_SIZE_LEN,
+        output.len() + bytestring_length <= MAX_MESSAGE_SIZE_LEN,
         "Tried to encode a message that is too large."
     );
 
@@ -753,7 +740,7 @@ fn encrypt_message_3(
     let ciphertext_3: BufferCiphertext3 =
         crypto.aes_ccm_encrypt_tag_8(&k_3, &iv_3, &enc_structure[..], plaintext_3.as_slice());
 
-    output.content[prefix_length..][..ciphertext_3.len].copy_from_slice(ciphertext_3.as_slice());
+    output.extend_from_slice(ciphertext_3.as_slice()).unwrap();
 
     output
 }
@@ -768,19 +755,19 @@ fn decrypt_message_3(
     let bytestring_length: usize;
     let prefix_length;
     // FIXME: Reuse CBOR decoder
-    if (0..=23).contains(&(message_3.content[0] ^ CBOR_MAJOR_BYTE_STRING)) {
-        bytestring_length = (message_3.content[0] ^ CBOR_MAJOR_BYTE_STRING).into();
+    if (0..=23).contains(&(message_3[0] ^ CBOR_MAJOR_BYTE_STRING)) {
+        bytestring_length = (message_3[0] ^ CBOR_MAJOR_BYTE_STRING).into();
         prefix_length = 1;
     } else {
         // FIXME: Assumes we don't exceed 256 bytes which is the current buffer size
-        bytestring_length = message_3.content[1].into();
+        bytestring_length = message_3[1].into();
         prefix_length = 2;
     }
 
-    let mut ciphertext_3: BufferCiphertext3 = BufferCiphertext3::new();
-    ciphertext_3.len = bytestring_length;
-    ciphertext_3.content[..bytestring_length]
-        .copy_from_slice(&message_3.content[prefix_length..][..bytestring_length]);
+    let ciphertext_3: BufferCiphertext3 = BufferCiphertext3::new_from_slice(
+        &message_3.as_slice()[prefix_length..][..bytestring_length],
+    )
+    .unwrap();
 
     let (k_3, iv_3) = compute_k_3_iv_3(crypto, prk_3e2m, th_3);
 
@@ -796,24 +783,18 @@ fn encrypt_message_4(
     plaintext_4: &BufferPlaintext4,
 ) -> BufferMessage4 {
     let mut output: BufferMessage4 = BufferMessage4::new();
-    let bytestring_length = plaintext_4.len + AES_CCM_TAG_LEN;
-    let prefix_length;
+    let bytestring_length = plaintext_4.len() + AES_CCM_TAG_LEN;
     // FIXME: Reuse CBOR encoder
     if bytestring_length < 24 {
-        output.content[0] = CBOR_MAJOR_BYTE_STRING | (bytestring_length) as u8;
-        prefix_length = 1;
+        output
+            .push(CBOR_MAJOR_BYTE_STRING | (bytestring_length) as u8)
+            .unwrap();
     } else {
         // FIXME: Assumes we don't exceed 256 bytes which is the current buffer size
-        output.content[0] = CBOR_MAJOR_BYTE_STRING | 24;
-        output.content[1] = bytestring_length as _;
-        prefix_length = 2;
+        output.push(CBOR_MAJOR_BYTE_STRING | 24).unwrap();
+        output.push(bytestring_length as _).unwrap();
     };
-    output.len = prefix_length + bytestring_length;
     // FIXME: Make the function fallible, especially with the prospect of algorithm agility
-    assert!(
-        output.len <= MAX_MESSAGE_SIZE_LEN,
-        "Tried to encode a message that is too large."
-    );
 
     let enc_structure = encode_enc_structure(th_4);
 
@@ -822,7 +803,7 @@ fn encrypt_message_4(
     let ciphertext_4: BufferCiphertext4 =
         crypto.aes_ccm_encrypt_tag_8(&k_4, &iv_4, &enc_structure[..], plaintext_4.as_slice());
 
-    output.content[prefix_length..][..ciphertext_4.len].copy_from_slice(ciphertext_4.as_slice());
+    output.extend_from_slice(ciphertext_4.as_slice()).unwrap();
 
     output
 }
@@ -837,19 +818,19 @@ fn decrypt_message_4(
     let bytestring_length: usize;
     let prefix_length;
     // FIXME: Reuse CBOR decoder
-    if (0..=23).contains(&(message_4.content[0] ^ CBOR_MAJOR_BYTE_STRING)) {
-        bytestring_length = (message_4.content[0] ^ CBOR_MAJOR_BYTE_STRING).into();
+    if (0..=23).contains(&(message_4[0] ^ CBOR_MAJOR_BYTE_STRING)) {
+        bytestring_length = (message_4[0] ^ CBOR_MAJOR_BYTE_STRING).into();
         prefix_length = 1;
     } else {
         // FIXME: Assumes we don't exceed 256 bytes which is the current buffer size
-        bytestring_length = message_4.content[1].into();
+        bytestring_length = message_4[1].into();
         prefix_length = 2;
     }
 
-    let mut ciphertext_4: BufferCiphertext4 = BufferCiphertext4::new();
-    ciphertext_4.len = bytestring_length;
-    ciphertext_4.content[..bytestring_length]
-        .copy_from_slice(&message_4.content[prefix_length..][..bytestring_length]);
+    let ciphertext_4 = BufferCiphertext4::new_from_slice(
+        &message_4.as_slice()[prefix_length..][..bytestring_length],
+    )
+    .unwrap();
 
     let (k_4, iv_4) = compute_k_4_iv_4(crypto, prk_4e3m, th_4);
 
@@ -890,8 +871,8 @@ fn encode_kdf_context(
 
     output_len += if let Some(ead) = ead {
         let encoded_ead = encode_ead_item(ead).unwrap(); // NOTE: this re-encoding could be avoided by passing just a reference to ead in the decrypted plaintext
-        output[output_len..output_len + encoded_ead.len].copy_from_slice(encoded_ead.as_slice());
-        encoded_ead.len
+        output[output_len..output_len + encoded_ead.len()].copy_from_slice(encoded_ead.as_slice());
+        encoded_ead.len()
     } else {
         0
     };
@@ -967,11 +948,11 @@ fn encode_plaintext_2(
     plaintext_2
         .extend_from_slice(id_cred_r)
         .or(Err(EDHOCError::EncodingError))?;
-    let offset_cred = plaintext_2.len;
 
-    plaintext_2.content[offset_cred] = CBOR_MAJOR_BYTE_STRING | MAC_LENGTH_2 as u8;
-    plaintext_2.content[1 + offset_cred..1 + offset_cred + mac_2.len()].copy_from_slice(&mac_2[..]);
-    plaintext_2.len = 1 + offset_cred + mac_2.len();
+    plaintext_2
+        .push(CBOR_MAJOR_BYTE_STRING | MAC_LENGTH_2 as u8)
+        .unwrap();
+    plaintext_2.extend_from_slice(&mac_2[..]).unwrap();
 
     if let Some(ead_2) = ead_2 {
         match encode_ead_item(ead_2) {
@@ -996,13 +977,12 @@ fn encrypt_decrypt_ciphertext_2(
     ciphertext_2: &BufferCiphertext2,
 ) -> BufferCiphertext2 {
     // KEYSTREAM_2 = EDHOC-KDF( PRK_2e,   0, TH_2,      plaintext_length )
-    let keystream_2 = edhoc_kdf(crypto, prk_2e, 0u8, th_2, ciphertext_2.len);
+    let keystream_2 = edhoc_kdf(crypto, prk_2e, 0u8, th_2, ciphertext_2.len());
 
     let mut result = BufferCiphertext2::default();
-    for i in 0..ciphertext_2.len {
-        result.content[i] = ciphertext_2.content[i] ^ keystream_2[i];
+    for i in 0..ciphertext_2.len() {
+        result.push(ciphertext_2[i] ^ keystream_2[i]).unwrap();
     }
-    result.len = ciphertext_2.len;
 
     result
 }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -610,7 +610,7 @@ fn edhoc_kdf(
 ) -> BytesMaxBuffer {
     let (info, info_len) = encode_info(label, context, length);
 
-    crypto.hkdf_expand(prk, &info, info_len, length)
+    crypto.hkdf_expand(prk, &info[..info_len], length)
 }
 
 fn encode_plaintext_3(

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -757,7 +757,8 @@ fn encrypt_message_3(
 
     let (k_3, iv_3) = compute_k_3_iv_3(crypto, prk_3e2m, th_3);
 
-    let ciphertext_3 = crypto.aes_ccm_encrypt_tag_8(&k_3, &iv_3, &enc_structure[..], plaintext_3);
+    let ciphertext_3: BufferCiphertext3 =
+        crypto.aes_ccm_encrypt_tag_8(&k_3, &iv_3, &enc_structure[..], plaintext_3.as_slice());
 
     output.content[prefix_length..][..ciphertext_3.len].copy_from_slice(ciphertext_3.as_slice());
 
@@ -792,7 +793,7 @@ fn decrypt_message_3(
 
     let enc_structure = encode_enc_structure(th_3);
 
-    crypto.aes_ccm_decrypt_tag_8(&k_3, &iv_3, &enc_structure, &ciphertext_3)
+    crypto.aes_ccm_decrypt_tag_8(&k_3, &iv_3, &enc_structure, ciphertext_3.as_slice())
 }
 
 fn encrypt_message_4(
@@ -825,7 +826,8 @@ fn encrypt_message_4(
 
     let (k_4, iv_4) = compute_k_4_iv_4(crypto, prk_4e3m, th_4);
 
-    let ciphertext_4 = crypto.aes_ccm_encrypt_tag_8(&k_4, &iv_4, &enc_structure[..], plaintext_4);
+    let ciphertext_4: BufferCiphertext4 =
+        crypto.aes_ccm_encrypt_tag_8(&k_4, &iv_4, &enc_structure[..], plaintext_4.as_slice());
 
     output.content[prefix_length..][..ciphertext_4.len].copy_from_slice(ciphertext_4.as_slice());
 
@@ -860,7 +862,7 @@ fn decrypt_message_4(
 
     let enc_structure = encode_enc_structure(th_4);
 
-    crypto.aes_ccm_decrypt_tag_8(&k_4, &iv_4, &enc_structure, &ciphertext_4)
+    crypto.aes_ccm_decrypt_tag_8(&k_4, &iv_4, &enc_structure, ciphertext_4.as_slice())
 }
 
 // output must hold id_cred.len() + cred.len()

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1287,7 +1287,7 @@ mod tests {
 
     #[test]
     fn test_parse_message_1_invalid_traces() {
-        let message_1_tv: EdhocMessageBuffer = BufferMessage1::from_hex(MESSAGE_1_INVALID_ARRAY_TV);
+        let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_INVALID_ARRAY_TV);
         assert_eq!(
             parse_message_1(&message_1_tv).unwrap_err(),
             EDHOCError::ParsingError
@@ -1314,7 +1314,7 @@ mod tests {
 
     #[test]
     fn test_parse_message_2_invalid_traces() {
-        let message_2_tv = BufferMessage1::from_hex(MESSAGE_2_INVALID_NUMBER_OF_CBOR_SEQUENCE_TV);
+        let message_2_tv = BufferMessage2::from_hex(MESSAGE_2_INVALID_NUMBER_OF_CBOR_SEQUENCE_TV);
         assert_eq!(
             parse_message_2(&message_2_tv).unwrap_err(),
             EDHOCError::ParsingError
@@ -1506,7 +1506,7 @@ mod tests {
 
     #[test]
     fn test_decode_plaintext_4() {
-        let plaintext_4_tv = BufferPlaintext2::from_hex(PLAINTEXT_4_TV);
+        let plaintext_4_tv = BufferPlaintext4::from_hex(PLAINTEXT_4_TV);
 
         let plaintext_4 = decode_plaintext_4(&plaintext_4_tv);
         assert!(plaintext_4.is_ok());
@@ -1531,7 +1531,7 @@ mod tests {
     #[test]
     fn test_decrypt_message_4() {
         let plaintext_4_tv = BufferPlaintext4::from_hex(PLAINTEXT_4_TV);
-        let message_4_tv = BufferMessage3::from_hex(MESSAGE_4_TV);
+        let message_4_tv = BufferMessage4::from_hex(MESSAGE_4_TV);
 
         let plaintext_4 =
             decrypt_message_4(&mut default_crypto(), &PRK_4E3M_TV, &TH_4_TV, &message_4_tv);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -294,7 +294,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiator<Crypto> {
         mut self,
         c_i: Option<ConnId>,
         ead_1: &Option<EADItem>,
-    ) -> Result<(EdhocInitiatorWaitM2<Crypto>, EdhocMessageBuffer), EDHOCError> {
+    ) -> Result<(EdhocInitiatorWaitM2<Crypto>, BufferMessage1), EDHOCError> {
         trace!("Enter prepare_message_1");
         let c_i = match c_i {
             Some(c_i) => c_i,
@@ -602,8 +602,8 @@ mod test {
 
     #[test]
     fn test_process_message_1() {
-        let message_1_tv_first_time = EdhocMessageBuffer::from_hex(MESSAGE_1_TV_FIRST_TIME);
-        let message_1_tv = EdhocMessageBuffer::from_hex(MESSAGE_1_TV);
+        let message_1_tv_first_time = BufferMessage1::from_hex(MESSAGE_1_TV_FIRST_TIME);
+        let message_1_tv = BufferMessage1::from_hex(MESSAGE_1_TV);
         let responder = EdhocResponder::new(
             default_crypto(),
             EDHOCMethod::StatStat,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -320,7 +320,7 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiator<Crypto> {
     }
 
     pub fn selected_cipher_suite(&self) -> u8 {
-        self.state.suites_i[self.state.suites_i.len - 1]
+        self.state.suites_i[self.state.suites_i.len() - 1]
     }
 }
 

--- a/shared/src/buffer.rs
+++ b/shared/src/buffer.rs
@@ -16,7 +16,7 @@ pub enum EdhocBufferError {
 /// Trying to have an API as similar as possible to `heapless::Vec`,
 /// so that in the future it can be hot-swappable by the application.
 // NOTE: how would this const generic thing work across the C and Python bindings?
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 #[repr(C)]
 pub struct EdhocBuffer<const N: usize> {
     pub content: [u8; N],

--- a/shared/src/buffer.rs
+++ b/shared/src/buffer.rs
@@ -58,11 +58,15 @@ impl<const N: usize> EdhocBuffer<N> {
     }
 
     pub fn get(self, index: usize) -> Option<u8> {
-        self.content.get(index).copied()
+        if index < self.len {
+            None
+        } else {
+            self.content.get(index).copied()
+        }
     }
 
     pub fn contains(&self, item: &u8) -> bool {
-        self.content.contains(item)
+        self.as_slice().contains(item)
     }
 
     pub fn push(&mut self, item: u8) -> Result<(), EdhocBufferError> {
@@ -76,7 +80,11 @@ impl<const N: usize> EdhocBuffer<N> {
     }
 
     pub fn get_slice(&self, start: usize, len: usize) -> Option<&[u8]> {
-        self.content.get(start..start + len)
+        if start.saturating_add(len) > self.len {
+            None
+        } else {
+            self.content.get(start..start + len)
+        }
     }
 
     pub fn as_slice(&self) -> &[u8] {
@@ -117,8 +125,9 @@ impl<const N: usize> EdhocBuffer<N> {
 
 impl<const N: usize> Index<usize> for EdhocBuffer<N> {
     type Output = u8;
+    #[track_caller]
     fn index(&self, item: usize) -> &Self::Output {
-        &self.content[item]
+        &self.as_slice()[item]
     }
 }
 

--- a/shared/src/buffer.rs
+++ b/shared/src/buffer.rs
@@ -19,10 +19,13 @@ pub enum EdhocBufferError {
 #[derive(PartialEq, Debug, Clone)]
 #[repr(C)]
 pub struct EdhocBuffer<const N: usize> {
+    #[deprecated]
     pub content: [u8; N],
+    #[deprecated(note = "use .len()")]
     pub len: usize,
 }
 
+#[allow(deprecated)]
 impl<const N: usize> Default for EdhocBuffer<N> {
     fn default() -> Self {
         EdhocBuffer {
@@ -32,6 +35,7 @@ impl<const N: usize> Default for EdhocBuffer<N> {
     }
 }
 
+#[allow(deprecated)]
 impl<const N: usize> EdhocBuffer<N> {
     pub const fn new() -> Self {
         EdhocBuffer {
@@ -150,6 +154,7 @@ impl<const N: usize> EdhocBuffer<N> {
     }
 }
 
+#[allow(deprecated)]
 impl<const N: usize> Index<usize> for EdhocBuffer<N> {
     type Output = u8;
     #[track_caller]
@@ -158,6 +163,7 @@ impl<const N: usize> Index<usize> for EdhocBuffer<N> {
     }
 }
 
+#[allow(deprecated)]
 impl<const N: usize> TryFrom<&[u8]> for EdhocBuffer<N> {
     type Error = ();
 
@@ -176,6 +182,7 @@ impl<const N: usize> TryFrom<&[u8]> for EdhocBuffer<N> {
     }
 }
 
+#[allow(deprecated)]
 mod test {
 
     #[test]

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -51,7 +51,7 @@ impl From<u8> for IdCredType {
 /// let long_kid = IdCred::from_encoded_value(&hex!("43616263")).unwrap(); // 'abc'
 /// assert_eq!(long_kid.as_full_value(), &hex!("a10443616263")); // {4: 'abc'}
 /// ```
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[repr(C)]
 pub struct IdCred {
     /// The value is always stored in the ID_CRED_x form as a serialized one-element dictionary;
@@ -162,7 +162,7 @@ impl IdCred {
 /// Experimental support for CCS_PSK credentials is also available.
 // TODO: add back support for C and Python bindings
 #[cfg_attr(feature = "python-bindings", pyclass)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct Credential {
     /// Original bytes of the credential, CBOR-encoded

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -45,20 +45,20 @@ pub trait Crypto: core::fmt::Debug {
     fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen;
     fn hkdf_expand(&mut self, prk: &BytesHashLen, info: &[u8], length: usize) -> BytesMaxBuffer;
     fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
-    fn aes_ccm_encrypt_tag_8(
+    fn aes_ccm_encrypt_tag_8<const N: usize>(
         &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &[u8],
-        plaintext: &BufferPlaintext3,
-    ) -> BufferCiphertext3;
-    fn aes_ccm_decrypt_tag_8(
+        plaintext: &[u8],
+    ) -> EdhocBuffer<N>;
+    fn aes_ccm_decrypt_tag_8<const N: usize>(
         &mut self,
         key: &BytesCcmKeyLen,
         iv: &BytesCcmIvLen,
         ad: &[u8],
-        ciphertext: &BufferCiphertext3,
-    ) -> Result<BufferPlaintext3, EDHOCError>;
+        ciphertext: &[u8],
+    ) -> Result<EdhocBuffer<N>, EDHOCError>;
     fn p256_ecdh(
         &mut self,
         private_key: &BytesP256ElemLen,

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -42,7 +42,7 @@ pub trait Crypto: core::fmt::Debug {
         EdhocBuffer::<MAX_SUITES_LEN>::new_from_slice(&[EDHOCSuite::CipherSuite2 as u8])
             .expect("This should never fail, as the slice is of the correct length")
     }
-    fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen;
+    fn sha256_digest(&mut self, message: &[u8]) -> BytesHashLen;
     fn hkdf_expand(&mut self, prk: &BytesHashLen, info: &[u8], length: usize) -> BytesMaxBuffer;
     fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
     fn aes_ccm_encrypt_tag_8<const N: usize>(

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -43,13 +43,7 @@ pub trait Crypto: core::fmt::Debug {
             .expect("This should never fail, as the slice is of the correct length")
     }
     fn sha256_digest(&mut self, message: &BytesMaxBuffer, message_len: usize) -> BytesHashLen;
-    fn hkdf_expand(
-        &mut self,
-        prk: &BytesHashLen,
-        info: &BytesMaxInfoBuffer,
-        info_len: usize,
-        length: usize,
-    ) -> BytesMaxBuffer;
+    fn hkdf_expand(&mut self, prk: &BytesHashLen, info: &[u8], length: usize) -> BytesMaxBuffer;
     fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
     fn aes_ccm_encrypt_tag_8(
         &mut self,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -499,7 +499,7 @@ pub struct ProcessingM2 {
     pub th_2: BytesHashLen,
     pub x: BytesP256ElemLen,
     pub g_y: BytesP256ElemLen,
-    pub plaintext_2: EdhocMessageBuffer,
+    pub plaintext_2: BufferPlaintext2,
     pub c_r: ConnId,
     pub id_cred_r: IdCred,
     pub ead_2: Option<EADItem>,
@@ -520,7 +520,7 @@ pub struct ProcessingM3 {
     pub prk_3e2m: BytesHashLen,
     pub th_3: BytesHashLen,
     pub id_cred_i: IdCred,
-    pub plaintext_3: EdhocMessageBuffer,
+    pub plaintext_3: BufferPlaintext3,
     pub ead_3: Option<EADItem>,
 }
 


### PR DESCRIPTION
*Depends on: https://github.com/openwsn-berkeley/lakers/pull/365 (ignore the first few commits)*

The current shared buffer has all its members pub; that's not a good API design, especially as it means that an important invariant (len < CONST_LEN) is not upheld, as seen by an almost-bug in https://github.com/openwsn-berkeley/lakers/pull/360#discussion_r2102308069.

A large portion of the changes from this is that we go from

```
buffer.content[0] = 1;
buffer.content[1] = 2;
buffer.len = 2;
```

to

```
buffer.push(1).unwrap();
buffer.push(2).unwrap();
```

I'd prefer to have less unwrapping, but as a whole this is still easier to maintain (the maths got longer and longer in `buffer.content[thislenght + 2 + thatlength..thislength + 2 + thatlength + otherlength].copy_from_slice()`), and there was a possible panic implicit already (and we're running hax to tell us that it's fine). A better maintainable solution might be something like

```
let buffer = Buffer::<CONFIGURED_LENGTH>::new();
buffer.up_to::<20>.build()
    .push(1)
    .push(2)
    .extend_from_buffer(thing_with_a_maximum_length)
    .extend_from_array(hash);
buffer.extend_from_slice(slice)?;
```

where the up_to would be a const panic if CONFIGURED_LENGTH is insufficient, but that'd need some experimentation first.

<del>**Status**: So far, this is just preparatory commits (if we're to remove the direct pub access, we have to provide a few more methods), but I'd like to run them by CI step-by-step.</del>