### PR TITLE
Remove repr(C) from non-C-related code

### DIFF
--- a/ead/lakers-ead-authz/src/device.rs
+++ b/ead/lakers-ead-authz/src/device.rs
@@ -5,7 +5,6 @@ use defmt_or_log::trace;
 use lakers_shared::{Crypto as CryptoTrait, *};
 
 #[derive(Default, Debug)]
-#[repr(C)]
 pub struct ZeroTouchDevice {
     pub id_u: EdhocMessageBuffer, // identifier of the device (U), equivalent to ID_CRED_I in EDHOC
     pub g_w: BytesP256ElemLen,    // public key of the enrollment server (W)
@@ -13,14 +12,12 @@ pub struct ZeroTouchDevice {
 }
 
 #[derive(Default, Debug)]
-#[repr(C)]
 pub struct ZeroTouchDeviceWaitEAD2 {
     prk: BytesHashLen,
     pub h_message_1: BytesHashLen,
 }
 
 #[derive(Default, Debug)]
-#[repr(C)]
 pub struct ZeroTouchDeviceDone {
     pub voucher: BytesMac,
 }

--- a/ead/lakers-ead-authz/src/lib.rs
+++ b/ead/lakers-ead-authz/src/lib.rs
@@ -19,7 +19,6 @@ pub mod consts {
 }
 
 #[derive(PartialEq, Debug)]
-#[repr(C)]
 pub enum ZeroTouchError {
     InvalidEADLabel,
     EmptyEADValue,

--- a/shared/src/buffer.rs
+++ b/shared/src/buffer.rs
@@ -5,7 +5,6 @@ use core::ops::Index;
 pub const MAX_SUITES_LEN: usize = 9;
 
 #[derive(PartialEq, Debug)]
-#[repr(C)]
 pub enum EdhocBufferError {
     BufferAlreadyFull,
     SliceTooLong,
@@ -17,7 +16,6 @@ pub enum EdhocBufferError {
 /// so that in the future it can be hot-swappable by the application.
 // NOTE: how would this const generic thing work across the C and Python bindings?
 #[derive(PartialEq, Debug, Clone)]
-#[repr(C)]
 pub struct EdhocBuffer<const N: usize> {
     #[deprecated]
     pub content: [u8; N],

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -7,7 +7,6 @@ pub type BytesKeyAES128 = [u8; 16];
 pub type BytesKeyEC2 = [u8; 32];
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C)]
 pub enum CredentialKey {
     Symmetric(BytesKeyAES128),
     EC2Compact(BytesKeyEC2),
@@ -15,7 +14,6 @@ pub enum CredentialKey {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C)]
 pub enum CredentialType {
     CCS,
     #[allow(non_camel_case_types)]
@@ -52,7 +50,6 @@ impl From<u8> for IdCredType {
 /// assert_eq!(long_kid.as_full_value(), &hex!("a10443616263")); // {4: 'abc'}
 /// ```
 #[derive(Clone, Debug, Default, PartialEq)]
-#[repr(C)]
 pub struct IdCred {
     /// The value is always stored in the ID_CRED_x form as a serialized one-element dictionary;
     /// while this technically wastes two bytes, it has the convenient property of having the full
@@ -163,7 +160,6 @@ impl IdCred {
 // TODO: add back support for C and Python bindings
 #[cfg_attr(feature = "python-bindings", pyclass)]
 #[derive(Clone, Debug, PartialEq)]
-#[repr(C)]
 pub struct Credential {
     /// Original bytes of the credential, CBOR-encoded
     ///

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -427,7 +427,6 @@ impl EDHOCError {
 }
 
 /// Representation of an EDHOC ERR_CODE
-#[repr(C)]
 pub struct ErrCode(pub NonZeroI16);
 
 impl ErrCode {
@@ -453,7 +452,6 @@ impl ErrCode {
 }
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct InitiatorStart {
     pub suites_i: EdhocBuffer<MAX_SUITES_LEN>,
     pub method: u8,
@@ -478,7 +476,6 @@ pub struct ProcessingM1 {
 }
 
 #[derive(Clone, Debug)]
-#[repr(C)]
 pub struct WaitM2 {
     pub x: BytesP256ElemLen, // ephemeral private key of the initiator
     pub h_message_1: BytesHashLen,
@@ -492,7 +489,6 @@ pub struct WaitM3 {
 }
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct ProcessingM2 {
     pub mac_2: BytesMac2,
     pub prk_2e: BytesHashLen,
@@ -506,7 +502,6 @@ pub struct ProcessingM2 {
 }
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct ProcessedM2 {
     pub prk_3e2m: BytesHashLen,
     pub prk_4e3m: BytesHashLen,
@@ -541,7 +536,6 @@ pub struct ProcessedM3 {
 }
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct WaitM4 {
     pub prk_4e3m: BytesHashLen,
     pub th_4: BytesHashLen,
@@ -550,7 +544,6 @@ pub struct WaitM4 {
 }
 
 #[derive(Debug)]
-#[repr(C)]
 pub struct Completed {
     pub prk_out: BytesHashLen,
     pub prk_exporter: BytesHashLen,
@@ -559,7 +552,6 @@ pub struct Completed {
 /// An enum describing options how to send credentials.
 #[cfg_attr(feature = "python-bindings", pyclass(eq, eq_int))]
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[repr(C)]
 pub enum CredentialTransfer {
     /// This sends a short reference (key ID) of the credential.
     ///


### PR DESCRIPTION
Closes: https://github.com/openwsn-berkeley/lakers/issues/368

This is a breaking change, but we're there already. This might break things internally, but frankly I don't see how: We don't transmute, and all the C API bindings do have their copy_into_c style converters anyway.

Not making the types repr(C) allows the compiler to be smarter about them, and generally removes a promise we'd otherwise make and need to maintain.